### PR TITLE
Pylint 10.00/10, PySide6 UI, SVG system map, compliance fixes

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,53 @@
+name: Dependency vulnerability scan
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      # Hard fail if any vulnerability is found in either requirements file.
+      # Each step is separate so the failure identifies which file is affected.
+      - name: Audit Azure Functions dependencies
+        run: pip-audit --requirement requirements.txt
+
+      - name: Audit gen-ui dependencies (PySide6)
+        run: pip-audit --requirement gen-ui/requirements.txt
+
+      # Always generate and upload JSON reports, even when the audit steps fail,
+      # so the specific findings are available without re-running locally.
+      - name: Generate JSON reports
+        if: always()
+        run: |
+          pip-audit --requirement requirements.txt --format json \
+            --output azure-audit.json || true
+          pip-audit --requirement gen-ui/requirements.txt --format json \
+            --output genui-audit.json || true
+
+      - name: Upload audit reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-results
+          path: |
+            azure-audit.json
+            genui-audit.json
+          retention-days: 30

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
     "ms-python.python",
-    "ms-python.pylance",
-    "ms-python.vscode-pylance"
+    "ms-python.vscode-pylance",
+    "ms-python.pylint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   ],
   "python.testing.unittestEnabled": false,
   "python.analysis.venvPath": "${workspaceFolder}",
-  "python.analysis.venv": ".venv",
+  "python.analysis.venv": ".venv-1",
   "python.analysis.extraPaths": [
     "${workspaceFolder}"
   ],
@@ -25,15 +25,15 @@
   },
   "azureFunctions.deploySubpath": ".",
   "azureFunctions.scmDoBuildDuringDeployment": true,
-  "azureFunctions.pythonVenv": ".venv",
+  "azureFunctions.pythonVenv": ".venv-1",
   "azureFunctions.projectLanguage": "Python",
   "azureFunctions.projectRuntime": "~4",
   "debug.internalConsoleOptions": "neverOpen",
   "azureFunctions.projectLanguageModel": 2,
   "pylint.path": [
-    "${workspaceFolder}/.venv/bin/pylint"
+    "${workspaceFolder}/.venv-1/bin/pylint"
   ],
   "pylint.interpreter": [
-    "${workspaceFolder}/.venv/bin/python"
+    "${workspaceFolder}/.venv-1/bin/python"
   ]
 }

--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -1,7 +1,7 @@
 # VS Code Configuration Guide
 
 This guide explains how to configure Visual Studio Code so that it uses the
-same Python environment as Claude Code. When both share the same `.venv`,
+same Python environment as Claude Code. When both share the same `.venv-1`,
 import resolution, linting, and type checking produce consistent results.
 
 ---
@@ -10,12 +10,12 @@ import resolution, linting, and type checking produce consistent results.
 
 VS Code runs several independent tools — Pylance (IntelliSense), the Pylint
 extension, and the Python test runner — each with its own path configuration.
-If any of these resolves to a different Python than the project `.venv`, you
+If any of these resolves to a different Python than the project `.venv-1`, you
 will see errors in the Problems panel that Claude does not see (or vice versa),
 because they are literally running against different package sets.
 
-Claude Code invokes Python tools explicitly via `.venv/bin/python` and
-`.venv/bin/pylint` in the terminal. The settings below make VS Code do the
+Claude Code invokes Python tools explicitly via `.venv-1/bin/python` and
+`.venv-1/bin/pylint` in the terminal. The settings below make VS Code do the
 same.
 
 ---
@@ -23,21 +23,29 @@ same.
 ## Prerequisites
 
 The project virtual environment must be created and all dependencies installed
-before configuring VS Code.
+before configuring VS Code. The project venv is named `.venv-1` (not `.venv`).
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate          # macOS / Linux
-# .venv\Scripts\Activate.ps1       # Windows PowerShell
+python3.11 -m venv .venv-1
+source .venv-1/bin/activate          # macOS / Linux
+# .venv-1\Scripts\Activate.ps1       # Windows PowerShell
 pip install -r requirements.txt
 pip install pylint
+```
+
+The gen-ui desktop app has its own dependency (PySide6). Install it into the
+same venv:
+
+```bash
+pip install -r gen-ui/requirements.txt
 ```
 
 Verify:
 
 ```bash
-.venv/bin/python -c "import azure.functions; print('OK')"
-.venv/bin/python -m pylint --version
+.venv-1/bin/python -c "import azure.functions; print('OK')"
+.venv-1/bin/python -c "import PySide6; print('OK')"
+.venv-1/bin/pylint --version
 ```
 
 ---
@@ -50,8 +58,9 @@ the project (`.vscode/extensions.json` lists them as recommendations).
 | Extension | ID | Purpose |
 |-----------|----|---------|
 | Python | `ms-python.python` | Interpreter selection, test runner, debugger |
-| Pylance | `ms-python.pylance` | IntelliSense, import resolution, type checking |
+| Pylance | `ms-python.vscode-pylance` | IntelliSense, import resolution, type checking |
 | Pylint | `ms-python.pylint` | Lint errors and warnings in the Problems panel |
+| Azure Functions | `ms-azuretools.vscode-azurefunctions` | Local function host, deploy commands |
 
 ---
 
@@ -63,10 +72,10 @@ explains what each one does and why it is needed.
 ### Python interpreter
 
 ```json
-"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+"python.defaultInterpreterPath": "${workspaceFolder}/.venv-1/bin/python"
 ```
 
-Sets `.venv` as the fallback interpreter for the test runner and debugger.
+Sets `.venv-1` as the fallback interpreter for the test runner and debugger.
 This is **not** sufficient on its own — Pylance and Pylint each need additional
 settings, and the interpreter must also be actively selected (see below).
 
@@ -76,7 +85,7 @@ settings, and the interpreter must also be actively selected (see below).
 
 ```json
 "python.analysis.venvPath": "${workspaceFolder}",
-"python.analysis.venv": ".venv",
+"python.analysis.venv": ".venv-1",
 "python.analysis.extraPaths": ["${workspaceFolder}"],
 "python.analysis.typeCheckingMode": "basic"
 ```
@@ -84,21 +93,21 @@ settings, and the interpreter must also be actively selected (see below).
 | Setting | Purpose |
 |---------|---------|
 | `python.analysis.venvPath` | Tells Pylance where to look for virtual environments |
-| `python.analysis.venv` | Names the specific venv to use |
+| `python.analysis.venv` | Names the specific venv to use (`.venv-1`) |
 | `python.analysis.extraPaths` | Adds the project root so local modules resolve |
 | `python.analysis.typeCheckingMode` | `"basic"` matches the level used in development |
 
 Without `venvPath` + `venv`, Pylance cannot find third-party packages such as
-`azure.functions` and shows false "import could not be resolved" errors even
-when the package is correctly installed in `.venv`.
+`azure.functions` or `PySide6` and shows false "import could not be resolved"
+errors even when the package is correctly installed in `.venv-1`.
 
 ---
 
 ### Pylint extension — Problems panel linting
 
 ```json
-"pylint.path": ["${workspaceFolder}/.venv/bin/pylint"],
-"pylint.interpreter": ["${workspaceFolder}/.venv/bin/python"]
+"pylint.path": ["${workspaceFolder}/.venv-1/bin/pylint"],
+"pylint.interpreter": ["${workspaceFolder}/.venv-1/bin/python"]
 ```
 
 The Pylint extension runs as a separate process with its own path resolution.
@@ -111,10 +120,10 @@ produces different results from Claude's terminal runs.
 ## Selecting the interpreter
 
 `defaultInterpreterPath` is only a fallback; it is overridden by any previously
-stored selection. To ensure the active interpreter is `.venv`:
+stored selection. To ensure the active interpreter is `.venv-1`:
 
 1. `Cmd+Shift+P` → **Python: Select Interpreter**
-2. Choose the entry showing `.venv` — e.g. `Python 3.11.x ('.venv': venv)`
+2. Choose the entry showing `.venv-1` — e.g. `Python 3.11.x ('.venv-1': venv)`
 
 The selected interpreter appears in the status bar at the bottom of the window.
 Pylance picks it up immediately.
@@ -133,7 +142,7 @@ If stale warnings remain, run **Pylint: Restart Server**.
 **Terminal** — confirm the environment matches:
 
 ```bash
-.venv/bin/python -m pylint function_app.py
+.venv-1/bin/python -m pylint function_app.py
 # Expected: Your code has been rated at 10.00/10
 ```
 
@@ -141,15 +150,15 @@ If stale warnings remain, run **Pylint: Restart Server**.
 
 ## How Claude Code uses the environment
 
-Claude Code does not auto-activate the `.venv` — its Bash tool inherits the
+Claude Code does not auto-activate the `.venv-1` — its Bash tool inherits the
 system shell environment. Every Python invocation in this project therefore
 uses the explicit venv path:
 
 ```bash
-.venv/bin/python          # not: python
-.venv/bin/pip             # not: pip
-.venv/bin/python -m pylint  # not: pylint
-.venv/bin/python -m pytest  # not: pytest
+.venv-1/bin/python          # not: python
+.venv-1/bin/pip             # not: pip
+.venv-1/bin/python -m pylint  # not: pylint
+.venv-1/bin/pytest          # not: pytest
 ```
 
 This is equivalent to what VS Code does when the settings above are applied,
@@ -168,22 +177,32 @@ needs a full restart to pick up a newly selected interpreter.
 **Pylint shows different warnings from the terminal**
 
 Open the Output panel, select **Pylint** from the dropdown, and check the path
-in the startup log. If it does not show `.venv/bin/pylint`, confirm
+in the startup log. If it does not show `.venv-1/bin/pylint`, confirm
 `pylint.path` is saved in `.vscode/settings.json` and run
 **Pylint: Restart Server**.
 
-**`azure.functions` still unresolved after selecting `.venv`**
+**`azure.functions` still unresolved after selecting `.venv-1`**
 
 The package may not be installed. Verify with:
 
 ```bash
-.venv/bin/python -c "import azure.functions; print(azure.functions.__version__)"
+.venv-1/bin/python -c "import azure.functions; print(azure.functions.__version__)"
 ```
 
-If this fails, run `.venv/bin/pip install -r requirements.txt` and reload the
+If this fails, run `.venv-1/bin/pip install -r requirements.txt` and reload the
 window.
 
 **Wrong interpreter shown in the status bar**
 
 The status bar interpreter overrides `defaultInterpreterPath`. Use
 **Python: Select Interpreter** to correct it.
+
+**`PySide6` unresolved in `gen-ui/app.py`**
+
+PySide6 must be installed in `.venv-1`:
+
+```bash
+.venv-1/bin/pip install -r gen-ui/requirements.txt
+```
+
+Then run **Pylance: Restart Language Server**.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -19,6 +19,7 @@ A technical reference for developers working on the `traveller-world-gen` codeba
    - [function_app.py and shared/helpers.py](#47-function_apppy-and-sharedhelperspy)
    - [traveller_map_fetch.py](#48-traveller_map_fetchpy)
    - [system_map.py](#49-system_mappy)
+   - [gen-ui/app.py](#410-gen-uiapppy)
 5. [Key design decisions](#5-key-design-decisions)
 6. [Compliance audit history](#6-compliance-audit-history)
 7. [Deferred and out-of-scope features](#7-deferred-and-out-of-scope-features)
@@ -613,7 +614,12 @@ svg_str, canvas_height = build_svg(
 save_output(svg_str: str, path: str) -> None
 ```
 
-`build_svg()` calls `attach_detail()` internally (it needs world types and SAH codes to colour-code the arcs). The returned SVG string is self-contained and can be written to a file or embedded in HTML.
+`build_svg()` does **not** call `attach_detail()` itself. The CLI's `main()` calls it first so that arc colours and detail-table profiles are populated. When calling `build_svg()` programmatically, call `attach_detail(system)` beforehand if you want secondary world and moon data in the table. The returned SVG string is self-contained and can be written to a file or embedded in HTML.
+
+**SVG rendering in Qt (`QSvgWidget`):** Two properties of the SVG are set in ways that browsers support but Qt's SVG renderer does not:
+
+- *Background colour* — the CSS `background` property on the root `<svg>` element is ignored by Qt. The SVG output therefore includes an explicit `<rect x="0" y="0" width="…" height="…" fill="{palette.bg}"/>` as the first element inside the root, which all SVG renderers handle correctly.
+- *Font family inheritance* — Qt does not inherit `font-family` from a `style="…"` attribute on the root `<svg>` element. The table zone content is wrapped in `<g font-family="'Courier New', Courier, monospace">` so the monospace font is applied via an SVG presentation attribute, which Qt does inherit.
 
 **Colour palettes:**
 
@@ -642,6 +648,49 @@ python system_map.py --seed 42 --width 2400
 # Open in default viewer after writing (macOS/Linux)
 python system_map.py --name Mora --seed 7
 ```
+
+---
+
+### 4.10 `gen-ui/app.py`
+
+PySide6 (Qt6) desktop UI for local interactive use. Run with:
+
+```bash
+python gen-ui/app.py
+```
+
+**`AppWindow`** — the main window. Key instance state:
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `_current_world` | `object \| None` | Last generated `World` |
+| `_current_system` | `object \| None` | Last generated `TravellerSystem` |
+| `_detail_attached` | `bool` | Whether `attach_detail()` was called on `_current_system` |
+| `_html_path` | `str \| None` | Temp file path of the last HTML card (for "Open in Browser") |
+| `_map_btn` | `QPushButton \| None` | Reference to the active "System Map" button; `None` when no system result is displayed |
+| `_map_windows` | `list[object]` | Open `SystemMapWindow` instances; list keeps them alive (Python GC otherwise collects shown windows) |
+
+The "System Map" button lives in `_build_system_summary_header()` (system results only; not shown in world-only mode). It is enabled/disabled in sync with the "Full system" checkbox: `_on_full_system_toggled()` calls `_map_btn.setEnabled(checked)` when the reference is set, and `_clear_status()` nulls `_map_btn` whenever the result panel is replaced.
+
+**`SystemMapWindow`** — a non-modal `QMainWindow` opened by the "System Map" button. One window is created per click; multiple windows can coexist.
+
+```python
+class SystemMapWindow(QMainWindow):
+    _CANVAS_W = 1600       # fixed SVG width
+
+    # toolbar buttons:
+    _theme_btn   # "Light Theme" / "Dark Theme" toggle
+    # "Save SVG…" → QFileDialog → writes self._svg_str
+
+    def _render(self) -> None:
+        # calls build_svg(system, canvas_w, palette)
+        # loads result into QSvgWidget inside QScrollArea
+        # falls back to browser + hint label if PySide6.QtSvgWidgets unavailable
+```
+
+`_render()` is called once at construction and again on every theme toggle. The `QSvgWidget` is sized to the exact SVG canvas dimensions (`_CANVAS_W × canvas_h`) so the `QScrollArea` provides correct scrollbars for large maps.
+
+**Keyboard shortcuts** — `QKeySequence::Quit` (Cmd+Q on macOS, Ctrl+Q on Windows/Linux) and `QKeySequence::Close` (Cmd+W / Ctrl+W) are registered globally on `AppWindow`. Qt resolves the correct platform key automatically.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -18,6 +18,7 @@ A technical reference for developers working on the `traveller-world-gen` codeba
    - [traveller_moon_gen.py](#46-traveller_moon_genpy)
    - [function_app.py and shared/helpers.py](#47-function_apppy-and-sharedhelperspy)
    - [traveller_map_fetch.py](#48-traveller_map_fetchpy)
+   - [system_map.py](#49-system_mappy)
 5. [Key design decisions](#5-key-design-decisions)
 6. [Compliance audit history](#6-compliance-audit-history)
 7. [Deferred and out-of-scope features](#7-deferred-and-out-of-scope-features)
@@ -51,14 +52,15 @@ traveller-world-gen/
 ├── traveller_moon_gen.py       # Moon quantity, sizing, and SAH/social detail
 ├── traveller_map_fetch.py      # TravellerMap integration: fetch, parse UWP + stellar, reconstruct system
 ├── traveller_world_schema.json # JSON Schema (draft 2020-12) for World.to_dict()
+├── system_map.py               # SVG star system map: per-star arc zones, log-AU radial scale, orbit table
 │
 ├── function_app.py             # Azure Functions HTTP endpoints (13 routes)
 ├── shared/
 │   └── helpers.py              # Request parsing, response builders, error codes
 ├── gen-ui/
-│   ├── app.py                  # GTK4 desktop UI — fully working
+│   ├── app.py                  # PySide6 (Qt6) desktop UI — fully working
 │   ├── README.md               # Setup, usage, and keyboard shortcut reference
-│   └── requirements.txt        # Dependency notes (Homebrew) and HTML rendering constraints
+│   └── requirements.txt        # Dependency list (PySide6>=6.4.0; bundled Qt, no system libs required)
 │
 ├── tests/
 │   ├── test_traveller_world_gen.py   # Unit tests — mainworld generation
@@ -214,8 +216,8 @@ class OrbitSlot:
                             # mainworld placed here; takes display priority over detail.profile
     gg_sah: str             # gas giant SAH rolled at orbit-gen time (e.g. "GM9");
                             # empty string for non-gas-giant slots
-    # Attached after generate_system_detail():
-    detail: Optional[WorldDetail]  # set by attach_detail()
+    detail: Optional[WorldDetail] = field(default=None, init=False)
+                            # populated by attach_detail(); None until then
 
 @dataclass
 class SystemOrbits:
@@ -376,6 +378,7 @@ class WorldDetail:
     tech_level: int
     spaceport: str      # Y/H/G/F for secondaries; "-" default
     moons: list         # List[Moon], populated by attach_detail()
+    trade_codes: list   # List[str]; empty for gas giants and rings
 
     # computed properties:
     .inhabited -> bool
@@ -499,11 +502,19 @@ system: TravellerSystem = generate_system_from_map(
 ```
 
 Raises `LookupError` if the world is not found on TravellerMap.
+Raises `AmbiguousWorldError` if a name search matches more than one world in the same sector.
 Raises `urllib.error.URLError` if the API is unreachable.
 
 **Key dataclasses and functions:**
 
 ```python
+class AmbiguousWorldError(Exception):
+    # Raised when a name search matches more than one world in the same sector.
+    # Attributes:
+    name: str
+    sector: str
+    candidates: list  # list of (world_name: str, hex_pos: str) tuples
+
 @dataclass
 class MapWorldData:
     name: str
@@ -535,6 +546,8 @@ World data is fetched in two steps:
 
 If `hex_pos` is provided directly (bypassing name search), step 1 is skipped.
 `sector` is always required for both steps.
+
+**Duplicate world names within a sector:** The Spinward Marches alone has seven pairs of worlds sharing a name (e.g. Aramis at 2540 and 3110). `_name_to_hex()` raises `AmbiguousWorldError` (carrying a `candidates` list of `(name, hex)` tuples) when a name search returns more than one exact match. Callers that supply `hex_pos` directly bypass this entirely. The gen-ui shows a modal disambiguation dialog and re-calls with the selected hex position.
 
 **Pipeline inside `generate_system_from_map()`:**
 
@@ -577,6 +590,57 @@ python traveller_map_fetch.py --name Regina --sector "Spinward Marches" --format
 
 # Uninhabited worlds are handled correctly
 python traveller_map_fetch.py --name Tavonni --sector "Spinward Marches" --detail
+```
+
+---
+
+### 4.9 `system_map.py`
+
+Generates an SVG diagram of a complete star system. The canvas has two zones stacked vertically:
+
+- **Arc zones** — one per star that has orbit slots. Each zone uses its own log-AU radial scale so the star's orbits fill the available width. Arcs are right-facing semicircles; the sweep angle per orbit is set so every arc reaches the same top and bottom y-coordinate within its zone. Companion-star dashed arcs are rendered inside the primary zone for context.
+- **Table zone** — one column per star, listing orbit slots in orbit-number order. Column count grows with the stellar system; use `--width` to avoid cramping on multi-star systems.
+
+**Key public API:**
+
+```python
+svg_str, canvas_height = build_svg(
+    system: TravellerSystem,
+    canvas_w: int = 1600,
+    palette: ColourPalette = PALETTE_DARK,
+) -> tuple[str, int]
+
+save_output(svg_str: str, path: str) -> None
+```
+
+`build_svg()` calls `attach_detail()` internally (it needs world types and SAH codes to colour-code the arcs). The returned SVG string is self-contained and can be written to a file or embedded in HTML.
+
+**Colour palettes:**
+
+```python
+@dataclass(frozen=True)
+class ColourPalette:
+    bg, gg, inh, uninh, belt, star_pri, star_sec,
+    mainworld, text, dim, axis, leader: str
+
+PALETTE_DARK   # dark background (default)
+PALETTE_LIGHT  # white background (--white-bg flag)
+```
+
+**CLI:**
+
+```bash
+# Random system, dark background, written to /tmp/traveller_system_map.svg
+python system_map.py
+
+# Named system with seed, white background, custom output path
+python system_map.py --name Ardenne --seed 1000 --white-bg --out ardenne.svg
+
+# Wider canvas for multi-star systems
+python system_map.py --seed 42 --width 2400
+
+# Open in default viewer after writing (macOS/Linux)
+python system_map.py --name Mora --seed 7
 ```
 
 ---
@@ -728,6 +792,15 @@ python traveller_world_gen.py --name Cogri --seed 42 --json
 
 # Moon generation detail (legacy entry point)
 python traveller_world_detail.py --name Varanthos --seed 6056
+
+# SVG star system map (dark background by default)
+python system_map.py --name Ardenne --seed 1000 --out ardenne.svg
+
+# White background (for printing / light-theme display)
+python system_map.py --name Ardenne --seed 1000 --white-bg --out ardenne-light.svg
+
+# Wider canvas for multi-star systems
+python system_map.py --seed 42 --width 2400 --out multi-star.svg
 ```
 
 ### Running the tests
@@ -753,6 +826,12 @@ The Azure Functions SDK is stubbed automatically by `conftest.py` if not install
 pip install -r requirements.txt
 func start   # requires Azure Functions Core Tools v4
 ```
+
+### CI — dependency vulnerability scan
+
+`.github/workflows/dependency-audit.yml` runs `pip-audit` on every branch push and on pull requests targeting `main`. It audits `requirements.txt` and `gen-ui/requirements.txt` separately (two named steps) and hard-fails the workflow if any vulnerability is found. A JSON report artifact is always uploaded (30-day retention) so findings are readable without re-running locally.
+
+To make the audit a required check that blocks merges: Settings → Branches → branch protection rule for `main` → Require status checks → add `pip-audit`.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -876,6 +876,28 @@ pip install -r requirements.txt
 func start   # requires Azure Functions Core Tools v4
 ```
 
+### Linting (Pylint)
+
+All six generation modules target **10.00/10 per file** with Pylint 4.x. Check a single file:
+
+```bash
+.venv-1/bin/pylint traveller_stellar_gen.py
+```
+
+Multi-file runs will show R0801 (duplicate-code) due to shared HTML boilerplate in `traveller_system_gen.py` and `traveller_world_gen.py`. This is expected — the code is intentionally kept separate (different data structures) and the per-file target is what matters.
+
+Common inline suppression comments used in this codebase (with `# pylint: disable=`):
+
+| Message | Reason |
+|---------|--------|
+| `too-many-arguments` / `too-many-positional-arguments` | Helpers with 5+ params |
+| `too-many-locals` | Complex generation functions |
+| `too-many-instance-attributes` | Dataclasses and `__slots__` classes |
+| `too-many-branches` / `too-many-statements` / `too-many-return-statements` | Rule-table dispatch functions |
+| `import-outside-toplevel` | `argparse`/`sys` inside `main()`; lazy imports to break circular deps |
+| `locally-disabled,suppressed-message` | Module-level disable comment to suppress I0011/I0020 noise |
+| `broad-exception-caught` | All endpoint handlers (deliberate) |
+
 ### CI — dependency vulnerability scan
 
 `.github/workflows/dependency-audit.yml` runs `pip-audit` on every branch push and on pull requests targeting `main`. It audits `requirements.txt` and `gen-ui/requirements.txt` separately (two named steps) and hard-fails the workflow if any vulnerability is found. A JSON report artifact is always uploaded (30-day retention) so findings are readable without re-running locally.

--- a/gen-ui/app.py
+++ b/gen-ui/app.py
@@ -51,6 +51,7 @@ from PySide6.QtWidgets import (  # noqa: E402
     QLabel,
     QLineEdit,
     QMainWindow,
+    QMessageBox,
     QPushButton,
     QRadioButton,
     QScrollArea,
@@ -58,6 +59,14 @@ from PySide6.QtWidgets import (  # noqa: E402
     QVBoxLayout,
     QWidget,
 )
+
+from system_map import build_svg, PALETTE_DARK, PALETTE_LIGHT  # noqa: E402
+
+try:
+    from PySide6.QtSvgWidgets import QSvgWidget as _QSvgWidget
+    _HAS_SVG_WIDGET = True
+except ImportError:
+    _HAS_SVG_WIDGET = False
 
 from traveller_map_fetch import AmbiguousWorldError, generate_system_from_map  # noqa: E402
 from traveller_system_gen import generate_full_system  # noqa: E402
@@ -191,6 +200,105 @@ def _detail_row(label_text: str, value_text: str, danger: bool = False) -> QWidg
 
 
 # ---------------------------------------------------------------------------
+# System map window
+# ---------------------------------------------------------------------------
+
+_MAP_CANVAS_W = 1600
+
+
+class SystemMapWindow(QMainWindow):
+    """Separate, non-modal window that renders an SVG system map."""
+
+    def __init__(self, system: object) -> None:
+        super().__init__()
+        mw = system.mainworld  # type: ignore[attr-defined]
+        name = mw.name if mw else "System"
+        self.setWindowTitle(f"System Map — {name}")
+        self.resize(min(_MAP_CANVAS_W + 40, 1400), 720)
+
+        self._system = system
+        self._palette = PALETTE_DARK
+        self._svg_str = ""
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        vbox = QVBoxLayout(central)
+        vbox.setContentsMargins(0, 0, 0, 0)
+        vbox.setSpacing(0)
+
+        toolbar = QWidget()
+        tbox = QHBoxLayout(toolbar)
+        tbox.setContentsMargins(8, 6, 8, 6)
+        tbox.setSpacing(8)
+
+        self._theme_btn = QPushButton("Light Theme")
+        self._theme_btn.clicked.connect(self._toggle_theme)
+        tbox.addWidget(self._theme_btn)
+
+        save_btn = QPushButton("Save SVG…")
+        save_btn.clicked.connect(self._on_save)
+        tbox.addWidget(save_btn)
+        tbox.addStretch()
+        vbox.addWidget(toolbar)
+        vbox.addWidget(_make_hsep())
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(False)
+        vbox.addWidget(self._scroll, stretch=1)
+
+        self._render()
+
+    def _render(self) -> None:
+        svg_str, canvas_h = build_svg(
+            self._system, canvas_w=_MAP_CANVAS_W, palette=self._palette
+        )
+        self._svg_str = svg_str
+
+        if _HAS_SVG_WIDGET:
+            widget = _QSvgWidget()  # type: ignore[possibly-undefined]
+            widget.load(svg_str.encode("utf-8"))
+            widget.setFixedSize(_MAP_CANVAS_W, canvas_h)
+            self._scroll.setWidget(widget)
+        else:
+            try:
+                fd, path = tempfile.mkstemp(suffix=".svg", prefix="traveller-map-")
+                os.close(fd)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(svg_str)
+                QDesktopServices.openUrl(QUrl.fromLocalFile(path))
+                msg = "System map opened in browser (PySide6.QtSvgWidgets not available)."
+            except OSError as exc:
+                msg = f"Could not write map: {exc}"
+            lbl = QLabel(msg)
+            lbl.setObjectName("hint-label")
+            lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._scroll.setWidget(lbl)
+
+    def _toggle_theme(self) -> None:
+        if self._palette is PALETTE_DARK:
+            self._palette = PALETTE_LIGHT
+            self._theme_btn.setText("Dark Theme")
+        else:
+            self._palette = PALETTE_DARK
+            self._theme_btn.setText("Light Theme")
+        self._render()
+
+    def _on_save(self) -> None:
+        mw = self._system.mainworld  # type: ignore[attr-defined]
+        base = (mw.name if mw else "system").replace(" ", "-").lower()
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save System Map", f"{base}-map.svg", "SVG files (*.svg)"
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(self._svg_str)
+        except OSError as exc:
+            QMessageBox.critical(self, "Save Failed", str(exc))
+
+
+# ---------------------------------------------------------------------------
 # Main window
 # ---------------------------------------------------------------------------
 
@@ -205,6 +313,8 @@ class AppWindow(QMainWindow):
         self._current_system: object | None = None
         self._detail_attached: bool = False
         self._seed_auto: bool = False
+        self._map_windows: list[object] = []
+        self._map_btn: QPushButton | None = None
         app = QApplication.instance()
         if isinstance(app, QApplication):
             app.setStyleSheet(_CSS)
@@ -380,6 +490,8 @@ class AppWindow(QMainWindow):
         self._check_attach_detail.setEnabled(checked)
         if not checked:
             self._check_attach_detail.setChecked(False)
+        if self._map_btn is not None:
+            self._map_btn.setEnabled(checked)
 
     def _on_source_toggled(self, checked: bool) -> None:  # pylint: disable=unused-argument
         procedural = self._radio_procedural.isChecked()
@@ -528,6 +640,13 @@ class AppWindow(QMainWindow):
                     error.sector, None, selected, seed, full_system, attach_detail_flag
                 )
 
+    def _on_map_clicked(self) -> None:
+        if self._current_system is None:
+            return
+        win = SystemMapWindow(self._current_system)
+        self._map_windows.append(win)
+        win.show()
+
     def _on_save_clicked(self) -> None:
         obj = self._current_system or self._current_world
         if obj is None:
@@ -594,6 +713,7 @@ class AppWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def _clear_status(self) -> None:
+        self._map_btn = None
         while self._status_layout.count():
             item = self._status_layout.takeAt(0)
             if item is not None:
@@ -713,6 +833,16 @@ class AppWindow(QMainWindow):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
         layout.addWidget(spacer)
+
+        map_btn = QPushButton("System Map")
+        map_btn.clicked.connect(self._on_map_clicked)
+        map_btn.setEnabled(self._check_full_system.isChecked())
+        self._map_btn = map_btn
+        layout.addWidget(map_btn)
+
+        vsep0 = _make_vsep()
+        vsep0.setContentsMargins(6, 0, 6, 0)
+        layout.addWidget(vsep0)
 
         orbit_toggle = QCheckBox("Stellar && Orbits")
         orbit_toggle.setChecked(True)

--- a/gen-ui/app.py
+++ b/gen-ui/app.py
@@ -25,6 +25,8 @@ AI assistance disclosure: developed with Claude (Anthropic).
 The human author reviewed, directed, and is responsible for the code.
 """
 
+# pylint: disable=wrong-import-position,no-name-in-module,import-error,too-many-lines
+
 import os
 import random
 import secrets
@@ -63,7 +65,7 @@ from PySide6.QtWidgets import (  # noqa: E402
 from system_map import build_svg, PALETTE_DARK, PALETTE_LIGHT  # noqa: E402
 
 try:
-    from PySide6.QtSvgWidgets import QSvgWidget as _QSvgWidget
+    from PySide6.QtSvgWidgets import QSvgWidget as _QSvgWidget  # pylint: disable=ungrouped-imports
     _HAS_SVG_WIDGET = True
 except ImportError:
     _HAS_SVG_WIDGET = False
@@ -172,11 +174,16 @@ def _orbit_profile(orbit: object) -> str:
 
 
 def _tl_era(tl: int) -> str:
-    if tl <= 3:  return "Primitive"
-    if tl <= 6:  return "Industrial"
-    if tl <= 9:  return "Pre-Stellar"
-    if tl <= 11: return "Early Stellar"
-    if tl <= 14: return "Average Stellar"
+    if tl <= 3:
+        return "Primitive"
+    if tl <= 6:
+        return "Industrial"
+    if tl <= 9:
+        return "Pre-Stellar"
+    if tl <= 11:
+        return "Early Stellar"
+    if tl <= 14:
+        return "Average Stellar"
     return "High Stellar"
 
 
@@ -206,7 +213,7 @@ def _detail_row(label_text: str, value_text: str, danger: bool = False) -> QWidg
 _MAP_CANVAS_W = 1600
 
 
-class SystemMapWindow(QMainWindow):
+class SystemMapWindow(QMainWindow):  # pylint: disable=too-few-public-methods
     """Separate, non-modal window that renders an SVG system map."""
 
     def __init__(self, system: object) -> None:
@@ -303,7 +310,9 @@ class SystemMapWindow(QMainWindow):
 # ---------------------------------------------------------------------------
 
 
-class AppWindow(QMainWindow):
+class AppWindow(QMainWindow):  # pylint: disable=too-few-public-methods,too-many-instance-attributes,attribute-defined-outside-init
+    """Main application window for the Traveller World Generator."""
+
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Traveller World Generator")
@@ -348,6 +357,7 @@ class AppWindow(QMainWindow):
         self._show_placeholder()
 
     def _build_controls(self) -> QWidget:
+        # pylint: disable=attribute-defined-outside-init
         row = QWidget()
         layout = QHBoxLayout(row)
         layout.setSpacing(8)
@@ -383,7 +393,8 @@ class AppWindow(QMainWindow):
 
         return row
 
-    def _build_source_row(self) -> QWidget:
+    def _build_source_row(self) -> QWidget:  # pylint: disable=too-many-locals,too-many-statements
+        # pylint: disable=attribute-defined-outside-init
         row = QWidget()
         layout = QHBoxLayout(row)
         layout.setSpacing(12)
@@ -540,7 +551,7 @@ class AppWindow(QMainWindow):
                 world = generate_world(name)
                 self._finish_generation(world)
 
-    def _do_travellermap_generation(
+    def _do_travellermap_generation(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         sector: str,
         search_name: "str | None",
@@ -594,7 +605,7 @@ class AppWindow(QMainWindow):
             self._html_path = path
         self._show_system_summary(system)
 
-    def _show_disambiguation_dialog(
+    def _show_disambiguation_dialog(  # pylint: disable=too-many-locals
         self,
         error: AmbiguousWorldError,
         seed: int,
@@ -675,7 +686,9 @@ class AppWindow(QMainWindow):
             content = obj.summary()  # type: ignore[attr-defined]
         else:
             if self._current_system is not None:
-                content = obj.to_html(detail_attached=self._detail_attached)  # type: ignore[attr-defined]
+                content = obj.to_html(  # type: ignore[attr-defined]
+                    detail_attached=self._detail_attached
+                )
             else:
                 content = obj.to_html()  # type: ignore[attr-defined]
 
@@ -803,8 +816,8 @@ class AppWindow(QMainWindow):
         self, system: object
     ) -> "tuple[QWidget, QCheckBox]":
         mw = system.mainworld  # type: ignore[attr-defined]
-        bar = QWidget()
-        layout = QHBoxLayout(bar)
+        header = QWidget()
+        layout = QHBoxLayout(header)
         layout.setSpacing(10)
         layout.setContentsMargins(0, 0, 0, 0)
 
@@ -853,9 +866,10 @@ class AppWindow(QMainWindow):
         layout.addWidget(vsep)
 
         layout.addWidget(self._build_action_buttons())
-        return bar, orbit_toggle
+        return header, orbit_toggle
 
     def _build_action_buttons(self) -> QWidget:
+        # pylint: disable=attribute-defined-outside-init
         box = QWidget()
         layout = QHBoxLayout(box)
         layout.setSpacing(8)
@@ -887,8 +901,8 @@ class AppWindow(QMainWindow):
         return box
 
     def _build_summary_header(self, world: object) -> QWidget:
-        bar = QWidget()
-        layout = QHBoxLayout(bar)
+        header = QWidget()
+        layout = QHBoxLayout(header)
         layout.setSpacing(10)
         layout.setContentsMargins(0, 0, 0, 0)
 
@@ -913,9 +927,9 @@ class AppWindow(QMainWindow):
         layout.addWidget(spacer)
 
         layout.addWidget(self._build_action_buttons())
-        return bar
+        return header
 
-    def _build_stellar_card(self, system: object) -> QGroupBox:
+    def _build_stellar_card(self, system: object) -> QGroupBox:  # pylint: disable=too-many-locals
         group = QGroupBox("Stellar System")
         grid = QGridLayout(group)
         grid.setSpacing(4)
@@ -953,7 +967,7 @@ class AppWindow(QMainWindow):
 
         return group
 
-    def _build_orbits_card(
+    def _build_orbits_card(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         self, system: object, detail_attached: bool = False
     ) -> QGroupBox:
         group = QGroupBox("System Orbits")
@@ -1033,7 +1047,7 @@ class AppWindow(QMainWindow):
             if detail_attached and detail is not None:
                 for mi, moon in enumerate(detail.moons or [], 1):  # type: ignore[attr-defined]
                     if moon.is_ring:
-                        ring_count = getattr(moon, "_ring_count", 1)
+                        ring_count = moon.ring_count
                         moon_profile = f"R{ring_count:02d}"
                         moon_type = "ring"
                         moon_codes = ""
@@ -1132,7 +1146,7 @@ class AppWindow(QMainWindow):
         )
         return row
 
-    def _build_detail_cards(self, w: object, d: dict) -> QWidget:
+    def _build_detail_cards(self, w: object, d: dict) -> QWidget:  # pylint: disable=too-many-locals
         row = QWidget()
         layout = QHBoxLayout(row)
         layout.setSpacing(8)
@@ -1147,14 +1161,24 @@ class AppWindow(QMainWindow):
         pb.setContentsMargins(8, 4, 8, 6)
         gear = d["atmosphere"]["survival_gear"]
         gear_danger = gear not in ("None", "Varies")
+        hydro_desc = d['hydrographics']['description'].split(' (')[0]
         for lbl_text, val_text, danger in [
-            ("Atmosphere",      f"{_to_hex(w.atmosphere)} — {d['atmosphere']['name']}", False),  # type: ignore[attr-defined]
-            ("Survival gear",   gear,                                                          gear_danger),
-            ("Temperature",     w.temperature,                                                 False),   # type: ignore[attr-defined]
-            ("Hydrographics",   f"{_to_hex(w.hydrographics)} — {d['hydrographics']['description'].split(' (')[0]}", False),  # type: ignore[attr-defined]
-            ("Gas giants",      str(w.gas_giant_count) if w.has_gas_giant else "None",        False),   # type: ignore[attr-defined]
-            ("Planetoid belts", str(w.belt_count),                                             False),   # type: ignore[attr-defined]
-            ("PBG",             f"{w.population_multiplier}{w.belt_count}{w.gas_giant_count}", False),   # type: ignore[attr-defined]
+            ("Atmosphere",
+             f"{_to_hex(w.atmosphere)} — {d['atmosphere']['name']}",  # type: ignore[attr-defined]
+             False),
+            ("Survival gear",   gear, gear_danger),
+            ("Temperature",     w.temperature, False),  # type: ignore[attr-defined]
+            ("Hydrographics",
+             f"{_to_hex(w.hydrographics)} — {hydro_desc}",  # type: ignore[attr-defined]
+             False),
+            ("Gas giants",
+             str(w.gas_giant_count) if w.has_gas_giant else "None",  # type: ignore[attr-defined]
+             False),
+            ("Planetoid belts", str(w.belt_count), False),  # type: ignore[attr-defined]
+            ("PBG",
+             f"{w.population_multiplier}"  # type: ignore[attr-defined]
+             f"{w.belt_count}{w.gas_giant_count}",  # type: ignore[attr-defined]
+             False),
         ]:
             pb.addWidget(_detail_row(lbl_text, val_text, danger))
         layout.addWidget(phys)
@@ -1166,13 +1190,18 @@ class AppWindow(QMainWindow):
         sb = QVBoxLayout(soc)
         sb.setSpacing(0)
         sb.setContentsMargins(8, 4, 8, 6)
-        pop_str = f"{_to_hex(w.population)} — {d['population']['range']}"  # type: ignore[attr-defined]
+        pop_str = (
+            f"{_to_hex(w.population)} — {d['population']['range']}"  # type: ignore[attr-defined]
+        )
         if w.population > 0:  # type: ignore[attr-defined]
             pop_str += f"  (P={w.population_multiplier})"  # type: ignore[attr-defined]
-        bases_str = "  ".join(_BASE_FULL.get(b, b) for b in w.bases) or "None"  # type: ignore[attr-defined]
+        bases_str = (
+            "  ".join(_BASE_FULL.get(b, b) for b in w.bases) or "None"  # type: ignore[attr-defined]
+        )
         for lbl_text, val_text in [
             ("Population", pop_str),
-            ("Government", f"{_to_hex(w.government)} — {d['government']['name']}"),  # type: ignore[attr-defined]
+            ("Government",
+             f"{_to_hex(w.government)} — {d['government']['name']}"),  # type: ignore[attr-defined]
             ("Law level",  _to_hex(w.law_level)),  # type: ignore[attr-defined]
             ("Bases",      bases_str),
         ]:
@@ -1231,6 +1260,7 @@ class AppWindow(QMainWindow):
 
 
 def main() -> None:
+    """Launch the Traveller World Generator desktop application."""
     app = QApplication(sys.argv)
     app.setApplicationName("Traveller World Generator")
     window = AppWindow()

--- a/system_map.py
+++ b/system_map.py
@@ -237,6 +237,9 @@ def build_svg(system: Any, canvas_w: int = 1600, palette: ColourPalette = PALETT
         f'width="{canvas_w}" height="{canvas_h}" '
         f'style="background:{palette.bg};font-family:\'Courier New\',monospace">'
     )
+    s.append(
+        f'<rect x="0" y="0" width="{canvas_w}" height="{canvas_h}" fill="{palette.bg}"/>'
+    )
 
     # ══════════════════════════════════════════════════════════════════════════
     # ARC ZONES — one per active star, stacked vertically
@@ -450,6 +453,7 @@ def build_svg(system: Any, canvas_w: int = 1600, palette: ColourPalette = PALETT
     # ══════════════════════════════════════════════════════════════════════════
     # TABLE ZONE — one column per star, rows grow downward
     # ══════════════════════════════════════════════════════════════════════════
+    s.append('<g font-family="\'Courier New\', Courier, monospace">')
     hdr_y  = sep_y + _TBL_HDR_OFF
     uln_y  = sep_y + _TBL_ULN_OFF
     row0_y = sep_y + _TBL_ROW0_OFF
@@ -560,6 +564,7 @@ def build_svg(system: Any, canvas_w: int = 1600, palette: ColourPalette = PALETT
                 f'{esc(hz_tag)}{esc(o.temperature_zone)}{esc(moons_str)}</text>'
             )
 
+    s.append('</g>')
     s.append('</svg>')
     return "\n".join(s), canvas_h
 

--- a/traveller_moon_gen.py
+++ b/traveller_moon_gen.py
@@ -92,10 +92,11 @@ class Moon:
     is_ring: bool = False
     is_gas_giant_moon: bool = False  # True if moon is itself a small GG
     detail: Optional["WorldDetail"] = None  # full SAH+social, populated later
-    _ring_count: int = field(default=1, init=False, repr=False)  # collapsed ring count
+    ring_count: int = field(default=1, init=False, repr=False)  # collapsed ring count
 
     @property
     def size_str(self) -> str:
+        """Return the display string for this moon's size code."""
         if self.is_ring:
             return "R"
         if self.size_code == "S":
@@ -117,7 +118,7 @@ class Moon:
             "is_gas_giant_moon": self.is_gas_giant_moon,
         }
         if self.is_ring:
-            d["ring_count"] = getattr(self, "_ring_count", 1)
+            d["ring_count"] = self.ring_count
         if self.detail is not None:
             d["detail"] = self.detail.to_dict()
         return d
@@ -174,21 +175,20 @@ def _size_terrestrial_moon(parent_size: int) -> Moon:
     r = random.randint(1, 6)
     if r <= 3:
         return Moon(size_code="S")
-    elif r <= 5:
+    if r <= 5:
         sz = _d3() - 1            # D3-1: 0, 1, or 2
         if sz == 0:
             return Moon(size_code=0, is_ring=True)
         # Clamp: moon cannot exceed parent size (WBH p.57)
         sz = min(sz, parent_size)
         return Moon(size_code=sz)
-    else:
-        # Size = (parent_size - 1) - 1D; negative → S, zero → ring (WBH p.57)
-        sz = (parent_size - 1) - random.randint(1, 6)
-        if sz < 0:
-            return Moon(size_code="S")
-        if sz == 0:
-            return Moon(size_code=0, is_ring=True)
-        return Moon(size_code=sz)
+    # Size = (parent_size - 1) - 1D; negative → S, zero → ring (WBH p.57)
+    sz = (parent_size - 1) - random.randint(1, 6)
+    if sz < 0:
+        return Moon(size_code="S")
+    if sz == 0:
+        return Moon(size_code=0, is_ring=True)
+    return Moon(size_code=sz)
 
 
 def _size_gg_moon(gg_diameter: int) -> Moon:
@@ -196,29 +196,28 @@ def _size_gg_moon(gg_diameter: int) -> Moon:
     r = random.randint(1, 6)
     if r <= 3:
         return Moon(size_code="S")
-    elif r <= 5:
+    if r <= 5:
         sz = _d3() - 1
         if sz == 0:
             return Moon(size_code=0, is_ring=True)
         return Moon(size_code=sz)
+    # Gas Giant Special Moon Sizing
+    r2 = random.randint(1, 6)
+    if r2 <= 3:
+        sz = random.randint(1, 6)             # 1D → 1-6
+    elif r2 <= 5:
+        sz = max(0, _roll(2) - 2)             # 2D-2 → 0-A
     else:
-        # Gas Giant Special Moon Sizing
-        r2 = random.randint(1, 6)
-        if r2 <= 3:
-            sz = random.randint(1, 6)             # 1D → 1-6
-        elif r2 <= 5:
-            sz = max(0, _roll(2) - 2)             # 2D-2 → 0-A
-        else:
-            sz = _roll(2, 4)                      # 2D+4 → 6-G
-            if sz >= 16:
-                # Size G = this moon is a small gas giant
-                gg_sz = _d3() + _d3()             # D3+D3 for GS diameter
-                return Moon(size_code=gg_sz, is_gas_giant_moon=True)
-        if sz == 0:
-            return Moon(size_code=0, is_ring=True)
-        # Clamp moon to be smaller than parent
-        sz = min(sz, gg_diameter - 1)
-        return Moon(size_code=max(1, sz))
+        sz = _roll(2, 4)                      # 2D+4 → 6-G
+        if sz >= 16:
+            # Size G = this moon is a small gas giant
+            gg_sz = _d3() + _d3()             # D3+D3 for GS diameter
+            return Moon(size_code=gg_sz, is_gas_giant_moon=True)
+    if sz == 0:
+        return Moon(size_code=0, is_ring=True)
+    # Clamp moon to be smaller than parent
+    sz = min(sz, gg_diameter - 1)
+    return Moon(size_code=max(1, sz))
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +238,7 @@ def _twin_check(moon: Moon, parent_size: int) -> Moon:
         r = _roll(2)
         if r == 2:
             return Moon(size_code=parent_size - 1)
-        elif r == 12:
+        if r == 12:
             return Moon(size_code=parent_size)
     return moon
 
@@ -259,7 +258,7 @@ def _consolidate(moons: List[Moon]) -> List[Moon]:
         return others
     # Represent all rings as a single Moon with ring_count attribute
     ring_entry = Moon(size_code=0, is_ring=True)
-    ring_entry._ring_count = len(rings)
+    ring_entry.ring_count = len(rings)
     return [ring_entry] + others
 
 
@@ -301,7 +300,7 @@ def generate_moons(
         return []
     if raw == 0:
         ring = Moon(size_code=0, is_ring=True)
-        ring._ring_count = 1
+        ring.ring_count = 1
         return [ring]
 
     moons: List[Moon] = []
@@ -318,8 +317,10 @@ def generate_moons(
 
     # Sort: rings first, then S, then numeric ascending
     def sort_key(m: Moon):
-        if m.is_ring: return (0, 0)
-        if m.size_code == "S": return (1, 0)
+        if m.is_ring:
+            return (0, 0)
+        if m.size_code == "S":
+            return (1, 0)
         return (2, int(m.size_code))
 
     return sorted(moons, key=sort_key)
@@ -332,7 +333,7 @@ def moons_str(moons: List[Moon]) -> str:
     parts = []
     for m in moons:
         if m.is_ring:
-            count = getattr(m, "_ring_count", 1)
+            count = m.ring_count
             parts.append(f"R{count:02d}")
         elif m.is_gas_giant_moon:
             parts.append(f"GS{_ehex(int(m.size_code))}")

--- a/traveller_orbit_gen.py
+++ b/traveller_orbit_gen.py
@@ -36,8 +36,10 @@ The human author reviewed, directed, and is responsible for the code.
 from __future__ import annotations
 import json, math, random
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 from traveller_stellar_gen import Star, StarSystem, _orbit_to_au, ORBIT_AU
+if TYPE_CHECKING:
+    from traveller_world_detail import WorldDetail
 
 
 def roll(n: int, dm: int = 0) -> int:
@@ -186,6 +188,7 @@ class OrbitSlot:
     notes: str = ""
     canonical_profile: str = ""  # UWP set when mainworld comes from canonical data
     gg_sah: str = ""             # gas giant SAH rolled at orbit gen time (e.g. "GM9")
+    detail: Optional["WorldDetail"] = field(default=None, init=False)
 
     def to_dict(self) -> dict:
         d = {
@@ -205,9 +208,8 @@ class OrbitSlot:
         if self.gg_sah:
             d["gg_sah"] = self.gg_sah
         # Include secondary world / satellite detail if attach_detail() has run
-        detail = getattr(self, "detail", None)
-        if detail is not None:
-            d["detail"] = detail.to_dict()
+        if self.detail is not None:
+            d["detail"] = self.detail.to_dict()
         return d
 
 
@@ -281,7 +283,7 @@ class SystemOrbits:
         for o in self.orbits:
             hz   = "★" if o.is_habitable_zone else " "
             mw   = "  ← mainworld" if o.is_mainworld_candidate else ""
-            detail = getattr(o, "detail", None)
+            detail = o.detail
             if o.canonical_profile:
                 profile = o.canonical_profile
             elif detail is not None:

--- a/traveller_orbit_gen.py
+++ b/traveller_orbit_gen.py
@@ -34,7 +34,9 @@ The human author reviewed, directed, and is responsible for the code.
 """
 
 from __future__ import annotations
-import json, math, random
+import json
+import math
+import random
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 from traveller_stellar_gen import Star, StarSystem, _orbit_to_au, ORBIT_AU
@@ -43,6 +45,7 @@ if TYPE_CHECKING:
 
 
 def roll(n: int, dm: int = 0) -> int:
+    """Roll n six-sided dice and return the sum plus dm, minimum 0."""
     return max(0, sum(random.randint(1, 6) for _ in range(n)) + dm)
 
 
@@ -120,6 +123,7 @@ def _interp(
 
 
 def get_mao(star: Star) -> float:
+    """Return the Minimum Allowable Orbit# for this star (WBH p.38)."""
     if star.spectral_type in ("D","BD"):
         return 0.01
     st = star.subtype if star.subtype is not None else 0
@@ -129,8 +133,10 @@ def get_mao(star: Star) -> float:
 def _au_to_orbit(au: float) -> float:
     keys = sorted(ORBIT_AU.keys())
     vals = [ORBIT_AU[k] for k in keys]
-    if au <= vals[0]: return float(keys[0])
-    if au >= vals[-1]: return float(keys[-1])
+    if au <= vals[0]:
+        return float(keys[0])
+    if au >= vals[-1]:
+        return float(keys[-1])
     for i in range(len(vals)-1):
         if vals[i] <= au <= vals[i+1]:
             frac = (au - vals[i]) / (vals[i+1] - vals[i])
@@ -139,17 +145,23 @@ def _au_to_orbit(au: float) -> float:
 
 
 def get_hzco(star: Star, combined_lum: Optional[float] = None) -> float:
+    """Return the Habitable Zone Centre Orbit# for this star (WBH p.42)."""
     lum = combined_lum if combined_lum is not None else star.luminosity
     hzco_au = math.sqrt(max(lum, 1e-10))
     return _au_to_orbit(hzco_au)
 
 
 def _temp_zone(deviation: float, hzco: float, orbit: float) -> str:  # pylint: disable=unused-argument
-    if deviation >= 1.0:   return "frozen"
-    elif deviation >= 0.2: return "cold"
-    elif deviation >= -0.2:return "temperate"
-    elif deviation >= -1.0:return "hot"
-    else:                  return "boiling"
+    """Map HZ deviation to temperature zone string."""
+    if deviation >= 1.0:
+        return "frozen"
+    if deviation >= 0.2:
+        return "cold"
+    if deviation >= -0.2:
+        return "temperate"
+    if deviation >= -1.0:
+        return "hot"
+    return "boiling"
 
 
 _GG_EHEX = "0123456789ABCDEFGHIJ"
@@ -175,7 +187,9 @@ def _gg_sah_roll(spectral: str, lum_class: str) -> str:
 
 
 @dataclass
-class OrbitSlot:
+class OrbitSlot:  # pylint: disable=too-many-instance-attributes
+    """One orbit slot in a star system, with world type and zone data."""
+
     star_designation: str
     orbit_number: float
     orbit_au: float
@@ -191,6 +205,7 @@ class OrbitSlot:
     detail: Optional["WorldDetail"] = field(default=None, init=False)
 
     def to_dict(self) -> dict:
+        """Serialise this orbit slot to a JSON-compatible dict."""
         d = {
             "star": self.star_designation,
             "orbit_number": round(self.orbit_number, 2),
@@ -214,7 +229,9 @@ class OrbitSlot:
 
 
 @dataclass
-class SystemOrbits:
+class SystemOrbits:  # pylint: disable=too-many-instance-attributes
+    """All orbit slots for a star system, with world counts and zone data."""
+
     stellar_system: StarSystem
     gas_giant_count: int = 0
     belt_count: int = 0
@@ -229,6 +246,7 @@ class SystemOrbits:
     star_hz_outer: Dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
+        """Serialise this system's orbits to a JSON-compatible dict."""
         return {
             "gas_giant_count": self.gas_giant_count,
             "belt_count": self.belt_count,
@@ -248,9 +266,10 @@ class SystemOrbits:
         }
 
     def to_json(self, indent=2):
+        """Serialise this system's orbits to a JSON string."""
         return json.dumps(self.to_dict(), indent=indent)
 
-    def summary(self) -> str:
+    def summary(self) -> str:  # pylint: disable=too-many-locals
         """
         Human-readable orbital summary.
 
@@ -302,7 +321,7 @@ class SystemOrbits:
             if detail is not None:
                 for mi, moon in enumerate(detail.moons or [], 1):
                     if moon.is_ring:
-                        rc = getattr(moon, "_ring_count", 1)
+                        rc = moon.ring_count
                         mp = f"R{rc:02d}"
                         ms = "ring system"
                     elif moon.detail is not None:
@@ -327,13 +346,12 @@ class SystemOrbits:
         return "\n".join(lines)
 
 
-def generate_orbits(system: StarSystem) -> SystemOrbits:
+def generate_orbits(system: StarSystem) -> SystemOrbits:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    """Generate all orbit slots for a star system (WBH pp.36-51)."""
     result = SystemOrbits(stellar_system=system)
     primary_stars = [s for s in system.stars if s.role != "companion"]
     has_companion = any(s.role == "companion" for s in system.stars)
     secondary_count = sum(1 for s in primary_stars if s.role != "primary")
-    primary = system.primary
-
     # World counts (WBH p.36-37)
     if roll(2) <= 9:
         r = roll(2)
@@ -425,22 +443,32 @@ def generate_orbits(system: StarSystem) -> SystemOrbits:
 
         mao = star_mao[d]
         hzco = star_hzco[d]
-        min_o, max_o = star_avail[d]
+        _, max_o = star_avail[d]
 
         # Baseline number (WBH p.44)
         bn_dm = 0
-        if has_companion: bn_dm -= 2
-        if star.lum_class in ("Ia","Ib","II"): bn_dm += 3
-        elif star.lum_class == "III": bn_dm += 2
-        elif star.lum_class == "IV":  bn_dm += 1
-        elif star.lum_class == "VI":  bn_dm -= 1
+        if has_companion:
+            bn_dm -= 2
+        if star.lum_class in ("Ia","Ib","II"):
+            bn_dm += 3
+        elif star.lum_class == "III":
+            bn_dm += 2
+        elif star.lum_class == "IV":
+            bn_dm += 1
+        elif star.lum_class == "VI":
+            bn_dm -= 1
         bn_dm -= secondary_count
         tw = result.total_worlds
-        if tw < 6: bn_dm -= 4
-        elif tw <= 9: bn_dm -= 3
-        elif tw <= 12: bn_dm -= 2
-        elif tw <= 15: bn_dm -= 1
-        elif tw >= 18: bn_dm += 1
+        if tw < 6:
+            bn_dm -= 4
+        elif tw <= 9:
+            bn_dm -= 3
+        elif tw <= 12:
+            bn_dm -= 2
+        elif tw <= 15:
+            bn_dm -= 1
+        elif tw >= 18:
+            bn_dm += 1
         baseline_num = max(0, roll(2, bn_dm))
 
         # Baseline Orbit# (WBH p.44-46)
@@ -526,7 +554,8 @@ def generate_orbits(system: StarSystem) -> SystemOrbits:
             if si in empty_set:
                 wtype = "empty"
             elif pool_idx < len(pool):
-                wtype = pool[pool_idx]; pool_idx += 1
+                wtype = pool[pool_idx]
+                pool_idx += 1
             else:
                 wtype = "terrestrial"
             slot_gg_sah = (
@@ -567,16 +596,20 @@ def generate_orbits(system: StarSystem) -> SystemOrbits:
         best.is_mainworld_candidate = True
         result.mainworld_orbit = best
         notes = []
-        if best.is_habitable_zone: notes.append("in HZ")
-        if best.hz_deviation < -0.5: notes.append("warm side")
-        elif best.hz_deviation > 0.5: notes.append("cool side")
+        if best.is_habitable_zone:
+            notes.append("in HZ")
+        if best.hz_deviation < -0.5:
+            notes.append("warm side")
+        elif best.hz_deviation > 0.5:
+            notes.append("cool side")
         best.notes = ", ".join(notes)
 
     return result
 
 
 def generate_full_system(seed=None):
-    from traveller_stellar_gen import generate_stellar_data
+    """Generate a stellar system with orbits, optionally seeding the RNG."""
+    from traveller_stellar_gen import generate_stellar_data  # pylint: disable=import-outside-toplevel
     if seed is not None:
         random.seed(seed)
     system = generate_stellar_data()
@@ -590,10 +623,11 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
-    system, orbits = generate_full_system(args.seed)
+    _system, _orbits = generate_full_system(args.seed)
     if args.json:
-        d = system.to_dict(); d["orbits"] = orbits.to_dict()
-        print(json.dumps(d, indent=2))
+        data = _system.to_dict()
+        data["orbits"] = _orbits.to_dict()
+        print(json.dumps(data, indent=2))
     else:
-        print(system.summary())
-        print(orbits.summary())
+        print(_system.summary())
+        print(_orbits.summary())

--- a/traveller_stellar_gen.py
+++ b/traveller_stellar_gen.py
@@ -50,6 +50,7 @@ This is an unofficial fan work, not affiliated with Mongoose Publishing.
 AI assistance disclosure: developed with Claude (Anthropic).
 The human author reviewed, directed, and is responsible for the code.
 """
+# pylint: disable=too-many-lines,locally-disabled,suppressed-message
 
 from __future__ import annotations
 
@@ -323,7 +324,7 @@ def _interp_temp(spectral: str, subtype: int) -> Optional[int]:
 # ---------------------------------------------------------------------------
 
 @dataclass
-class Star:
+class Star:  # pylint: disable=too-many-instance-attributes
     """Represents one star in a system."""
 
     designation: str            # e.g. "Aa", "Ab", "B", "Ca"
@@ -351,9 +352,11 @@ class Star:
         return f"{self.spectral_type}{sub} {self.lum_class}"
 
     def colour(self) -> str:
+        """Return the display colour for this star's spectral type."""
         return SPECTRAL_COLOUR.get(self.spectral_type, "Unknown")
 
     def to_dict(self) -> dict:
+        """Serialise this star to a JSON-compatible dict."""
         return {
             "designation": self.designation,
             "role": self.role,
@@ -368,7 +371,8 @@ class Star:
             "orbit_number": round(self.orbit_number, 2) if self.orbit_number is not None else None,
             "orbit_au": round(self.orbit_au, 3) if self.orbit_au is not None else None,
             "age_gyr": round(self.age_gyr, 3) if self.age_gyr is not None else None,
-            "ms_lifespan_gyr": round(self.ms_lifespan_gyr, 2) if self.ms_lifespan_gyr is not None else None,
+            "ms_lifespan_gyr": (round(self.ms_lifespan_gyr, 2)
+                                if self.ms_lifespan_gyr is not None else None),
             "colour": self.colour(),
             "special_notes": self.special_notes,
         }
@@ -386,13 +390,16 @@ class StarSystem:
 
     @property
     def primary(self) -> Star:
+        """Return the primary star of the system."""
         return self.stars[0]
 
     @property
     def age_gyr(self) -> Optional[float]:
+        """Return the system age in Gyr (from the primary star)."""
         return self.primary.age_gyr
 
     def to_dict(self) -> dict:
+        """Serialise this star system to a JSON-compatible dict."""
         return {
             "star_count": len(self.stars),
             "age_gyr": round(self.age_gyr, 3) if self.age_gyr is not None else None,
@@ -400,13 +407,17 @@ class StarSystem:
         }
 
     def to_json(self, indent: int = 2) -> str:
+        """Serialise this star system to a JSON string."""
         return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
 
     def summary(self) -> str:
+        """Return a human-readable summary of this star system."""
+        age_str = (f"  System age   :  {self.age_gyr:.2f} Gyr"
+                   if self.age_gyr else "  System age   :  Unknown")
         lines = [
             "=" * 60,
             f"  Star system  —  {len(self.stars)} star(s)",
-            f"  System age   :  {self.age_gyr:.2f} Gyr" if self.age_gyr else "  System age   :  Unknown",
+            age_str,
             "=" * 60,
         ]
         for star in self.stars:
@@ -498,7 +509,7 @@ def _star_properties(
 # Subtype generation
 # ---------------------------------------------------------------------------
 
-def _roll_subtype(spectral: str, use_m_column: bool = False) -> int:
+def _roll_subtype(_spectral: str, use_m_column: bool = False) -> int:
     """
     Roll for numeric subtype using the Star Subtype table (WBH p.16).
     use_m_column=True for primary M-type stars.
@@ -551,7 +562,7 @@ def _orbit_to_au(orbit_num: float) -> float:
 # Primary star generation (WBH p.14-16)
 # ---------------------------------------------------------------------------
 
-def _generate_primary_star_type() -> Tuple[str, str]:
+def _generate_primary_star_type() -> Tuple[str, str]:  # pylint: disable=too-many-branches
     """
     Roll on the Star Type Determination table (WBH p.14-15).
     Returns (spectral_type, lum_class).
@@ -586,7 +597,7 @@ def _generate_primary_star_type() -> Tuple[str, str]:
                     spectral = "B"
             return spectral, lum_class
 
-        elif result == "Giants":
+        if result == "Giants":
             # Roll on Giants column
             r4 = roll(2)
             lum_class = GIANTS_COLUMN.get(r4, "Ia" if r4 >= 12 else "III")
@@ -596,8 +607,7 @@ def _generate_primary_star_type() -> Tuple[str, str]:
                 spectral = "G"
             return spectral, lum_class
 
-        else:
-            return "M", "V"
+        return "M", "V"
 
     if r == 12:
         # Hot column
@@ -650,7 +660,7 @@ def generate_primary_star(designation: str = "A") -> Star:
         )
 
     # Subtype
-    use_m_col = (spectral == "M")
+    use_m_col = spectral == "M"
     subtype = _roll_subtype(spectral, use_m_column=use_m_col)
 
     # Class IV special limits
@@ -758,7 +768,7 @@ def _multiple_star_dm(primary: Star) -> int:
     return 0
 
 
-def _determine_non_primary_type(
+def _determine_non_primary_type(  # pylint: disable=too-many-return-statements,too-many-branches,too-many-statements
     parent: Star,
     role: str,
     designation: str,
@@ -847,7 +857,8 @@ def _determine_non_primary_type(
 
     if result == "lesser":
         # Same class, one spectral type cooler; reroll subtype
-        sp_idx = SPECTRAL_ORDER.index(parent.spectral_type) if parent.spectral_type in SPECTRAL_ORDER else -1
+        sp_idx = (SPECTRAL_ORDER.index(parent.spectral_type)
+                  if parent.spectral_type in SPECTRAL_ORDER else -1)
         if sp_idx >= len(SPECTRAL_ORDER) - 1:
             # M-type lesser → M-type.
             # The lesser must be dimmer (higher subtype number) than the parent.
@@ -876,7 +887,8 @@ def _determine_non_primary_type(
         sub_reduction = random.randint(1, 6)
         new_sub = parent.subtype + sub_reduction  # higher number = dimmer
         # Wrap to next cooler type if needed
-        sp_idx = SPECTRAL_ORDER.index(parent.spectral_type) if parent.spectral_type in SPECTRAL_ORDER else -1
+        sp_idx = (SPECTRAL_ORDER.index(parent.spectral_type)
+                  if parent.spectral_type in SPECTRAL_ORDER else -1)
         if new_sub > 9:
             if sp_idx >= len(SPECTRAL_ORDER) - 1:
                 return _build_star("BD", "BD", designation, role)
@@ -987,7 +999,7 @@ def _secondary_orbit(slot: str) -> Tuple[float, float]:
 # Top-level system generation
 # ---------------------------------------------------------------------------
 
-def generate_stellar_data() -> StarSystem:
+def generate_stellar_data() -> StarSystem:  # pylint: disable=too-many-locals
     """
     Generate complete stellar data for a star system.
 
@@ -1068,7 +1080,8 @@ def generate_stellar_data() -> StarSystem:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    import argparse
+    """Generate and print Traveller stellar data from the command line."""
+    import argparse  # pylint: disable=import-outside-toplevel
 
     parser = argparse.ArgumentParser(
         description="Generate Traveller (WBH) stellar data for a star system."

--- a/traveller_system_gen.py
+++ b/traveller_system_gen.py
@@ -75,8 +75,12 @@ from traveller_world_gen import (
     generate_population_multiplier,
     assign_trade_codes,
     assign_travel_zone,
+    to_hex,
     ATMOSPHERE_MIN_TL,
     ATMOSPHERE_NAMES,
+    GOVERNMENT_NAMES,
+    HYDROGRAPHIC_NAMES,
+    STARPORT_QUALITY_LABEL,
     TEMPERATURE_DM,
 )
 
@@ -85,7 +89,7 @@ from traveller_world_gen import (
 # HZ deviation → raw temperature roll  (WBH p.46-47)
 # ---------------------------------------------------------------------------
 
-def hz_deviation_to_raw_roll(
+def hz_deviation_to_raw_roll(  # pylint: disable=unused-argument
     hz_deviation: float,
     hzco: float,
     orbit: float,
@@ -172,12 +176,14 @@ class TravellerSystem:
     mainworld_orbit: Optional[OrbitSlot]
 
     def to_dict(self) -> dict:
+        """Serialise this system to a JSON-compatible dict."""
         d = self.stellar_system.to_dict()
         d["orbits"] = self.system_orbits.to_dict()
         d["mainworld"] = self.mainworld.to_dict() if self.mainworld else None
         return d
 
     def to_json(self, indent: int = 2) -> str:
+        """Serialise this system to a JSON string."""
         return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
 
     def summary(self) -> str:
@@ -197,7 +203,7 @@ class TravellerSystem:
         )
 
         if detail_attached:
-            from traveller_world_detail import system_body_table
+            from traveller_world_detail import system_body_table  # pylint: disable=import-outside-toplevel
             orbital_section = system_body_table(self)
         else:
             orbital_section = self.system_orbits.summary()
@@ -218,7 +224,7 @@ class TravellerSystem:
             lines.append(mw.summary())
         return "\n".join(lines)
 
-    def to_html(self, detail_attached: bool = False) -> str:
+    def to_html(self, detail_attached: bool = False) -> str:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Return a self-contained HTML system card.
 
         Suitable for saving as a standalone .html file or serving directly
@@ -231,12 +237,7 @@ class TravellerSystem:
             Pass True when attach_detail() has already been called so the
             card includes secondary world profiles and satellite data.
         """
-        from traveller_world_detail import system_body_table
-        from traveller_world_gen import STARPORT_QUALITY, to_hex
-
         mw  = self.mainworld
-        mwo = self.mainworld_orbit
-        st  = self.stellar_system.primary
 
         def esc(s: str) -> str:
             return (str(s).replace("&","&amp;").replace("<","&lt;")
@@ -312,7 +313,7 @@ class TravellerSystem:
             if detail is not None:
                 for mi, moon in enumerate(detail.moons or [], 1):
                     if moon.is_ring:
-                        rc = getattr(moon, "_ring_count", 1)
+                        rc = moon.ring_count
                         mp = f"R{rc:02d}"
                         moon_codes_html = ""
                     elif moon.detail is not None:
@@ -336,10 +337,6 @@ class TravellerSystem:
 
         # ── Mainworld panel ───────────────────────────────────────────────
         if mw:
-            from traveller_world_gen import (
-                ATMOSPHERE_NAMES, GOVERNMENT_NAMES,
-                HYDROGRAPHIC_NAMES, STARPORT_QUALITY_LABEL,
-            )
             trade_badges = "".join(
                 f'<span class="badge trade">{esc(tc)}</span>'
                 for tc in mw.trade_codes
@@ -374,7 +371,8 @@ class TravellerSystem:
             mw_panel = '<p class="no-val">No mainworld determined.</p>'
 
         title       = esc(mw.name if mw else "Unknown") + " system"
-        age         = f"{self.stellar_system.age_gyr:.2f} Gyr" if self.stellar_system.age_gyr else "?"
+        age         = (f"{self.stellar_system.age_gyr:.2f} Gyr"
+                       if self.stellar_system.age_gyr else "?")
         nw          = self.system_orbits.total_worlds
         star_classes = " + ".join(esc(s.classification()) for s in self.stellar_system.stars)
 
@@ -751,8 +749,9 @@ def generate_system_from_world(
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    import argparse
-    import sys as _sys
+    """Generate a Traveller star system and print it to stdout."""
+    import argparse  # pylint: disable=import-outside-toplevel
+    import sys as _sys  # pylint: disable=import-outside-toplevel
 
     parser = argparse.ArgumentParser(
         description=(
@@ -794,7 +793,7 @@ def main() -> None:
         out_format = "text"
         want_detail = args.detail
 
-    from traveller_world_detail import attach_detail
+    from traveller_world_detail import attach_detail  # pylint: disable=import-outside-toplevel
 
     for i in range(args.count):
         system = generate_full_system(
@@ -810,7 +809,7 @@ def main() -> None:
         elif out_format == "html":
             if args.count > 1:
                 _sys.stderr.write(
-                    f"Warning: --html with --count > 1 outputs multiple HTML documents.\n"
+                    "Warning: --html with --count > 1 outputs multiple HTML documents.\n"
                 )
             print(system.to_html(detail_attached=want_detail))
         else:

--- a/traveller_world_detail.py
+++ b/traveller_world_detail.py
@@ -108,7 +108,6 @@ The human author reviewed, directed, and is responsible for the code.
 from __future__ import annotations
 
 import random
-from typing import Optional
 
 from traveller_orbit_gen import OrbitSlot, SystemOrbits
 from traveller_system_gen import TravellerSystem, generate_temperature_from_orbit
@@ -560,8 +559,7 @@ def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:
             # Gas giants: never directly inhabited (moons are out of scope).
             # Reuse the SAH rolled at orbit-gen time if available so the
             # diameter seen here matches the mainworld satellite size constraint.
-            existing_sah = getattr(orbit, "gg_sah", "")
-            sah = (existing_sah if existing_sah
+            sah = (orbit.gg_sah if orbit.gg_sah
                    else _gas_giant_sah(host.spectral_type, host.lum_class))
             result[key] = WorldDetail(sah=sah)
 
@@ -694,7 +692,7 @@ def system_body_table(system: TravellerSystem) -> str:
     ]
 
     for o in orbits.orbits:
-        detail = getattr(o, "detail", None)
+        detail = o.detail
         mw_mark = " ← mainworld" if o.is_mainworld_candidate else ""
         if o.is_mainworld_candidate and system.mainworld:
             profile = system.mainworld.uwp()

--- a/traveller_world_detail.py
+++ b/traveller_world_detail.py
@@ -172,10 +172,9 @@ def _terrestrial_size() -> int:
     r = random.randint(1, 6)
     if r <= 2:
         return random.randint(1, 6)   # 1-6
-    elif r <= 4:
+    if r <= 4:
         return _roll(2)               # 2-12 (C)
-    else:
-        return _roll(2, 3)            # 5-15 (F)
+    return _roll(2, 3)                # 5-15 (F)
 
 
 def _gg_dm(star_spectral: str, star_lum_class: str) -> int:
@@ -194,10 +193,9 @@ def _gas_giant_sah(star_spectral: str, star_lum_class: str) -> str:
     cat = random.randint(1, 6) + _gg_dm(star_spectral, star_lum_class)
     if cat <= 2:
         return f"GS{_ehex(_d3() + _d3())}"         # 2-6
-    elif cat <= 4:
+    if cat <= 4:
         return f"GM{_ehex(random.randint(1,6) + 6)}" # 7-12
-    else:
-        return f"GL{_ehex(_roll(2, 6))}"             # 8-18
+    return f"GL{_ehex(_roll(2, 6))}"             # 8-18
 
 
 def _terrestrial_sah(orbit: OrbitSlot, hzco: float) -> tuple[int, int, int]:
@@ -237,8 +235,7 @@ def _secondary_population(max_pop: int) -> int:
     return random.randint(1, max_pop)
 
 
-def _secondary_government(population: int, mainworld_pop: int,
-                           mainworld_gov: int) -> int:
+def _secondary_government(mainworld_pop: int, mainworld_gov: int) -> int:
     """
     Government code for a dependent secondary world (WBH p.161-162).
     We use Case 1 (captive/dependent), which is the most common case.
@@ -251,15 +248,18 @@ def _secondary_government(population: int, mainworld_pop: int,
         r = max(1, r - 2)
     elif mainworld_gov == 6:
         r += mainworld_pop
-    if r <= 1:   return 0
-    elif r <= 2: return 1
-    elif r <= 3: return 2
-    elif r <= 4: return 3
-    else:        return 6
+    if r <= 1:
+        return 0
+    if r <= 2:
+        return 1
+    if r <= 3:
+        return 2
+    if r <= 4:
+        return 3
+    return 6
 
 
-def _secondary_law_level(government: int, mainworld_gov: int,
-                          mainworld_law: int) -> int:
+def _secondary_law_level(government: int, mainworld_law: int) -> int:
     """
     Law Level for a secondary world (WBH p.171).
     For captive governments (6): 1D determines relationship to mainworld.
@@ -269,14 +269,12 @@ def _secondary_law_level(government: int, mainworld_gov: int,
         r = random.randint(1, 6)
         if r <= 2:
             return max(0, _roll(2, -7 + 6))       # rerolled for Gov 6
-        elif r <= 4:
+        if r <= 4:
             return mainworld_law                    # equal to mainworld
-        elif r == 5:
+        if r == 5:
             return mainworld_law + 1                # mainworld + 1
-        else:
-            return mainworld_law + random.randint(1, 6)
-    else:
-        return max(0, _roll(2, -7 + government))
+        return mainworld_law + random.randint(1, 6)
+    return max(0, _roll(2, -7 + government))
 
 
 def _secondary_tech_level(atmosphere: int, mainworld_tl: int) -> int:
@@ -294,28 +292,34 @@ def _spaceport(population: int) -> str:
     Returns Y/H/G/F (not the full starport A-X scale).
     """
     dm = 0
-    if population >= 6:   dm = +2
-    elif population == 1: dm = -1
+    if population >= 6:
+        dm = 2
+    elif population == 1:
+        dm = -1
     r = random.randint(1, 6) + dm
-    if r <= 2:  return "Y"
-    elif r == 3: return "H"
-    elif r <= 5: return "G"
-    else:        return "F"
+    if r <= 2:
+        return "Y"
+    if r == 3:
+        return "H"
+    if r <= 5:
+        return "G"
+    return "F"
 
 
 # ---------------------------------------------------------------------------
 # WorldDetail dataclass attached to each OrbitSlot
 # ---------------------------------------------------------------------------
 
-class WorldDetail:
+class WorldDetail:  # pylint: disable=too-many-instance-attributes
     """Physical and social details for one orbit slot."""
 
     __slots__ = ("sah", "population", "government", "law_level",
                  "tech_level", "spaceport", "moons", "trade_codes")
 
-    def __init__(self, sah: str, population: int = 0, government: int = 0,
-                 law_level: int = 0, tech_level: int = 0, spaceport: str = "-",
-                 moons: list[Moon] | None = None):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+            self, sah: str, population: int = 0, government: int = 0,
+            law_level: int = 0, tech_level: int = 0, spaceport: str = "-",
+            moons: list[Moon] | None = None):
         self.sah        = sah
         self.population = population
         self.government = government
@@ -339,6 +343,7 @@ class WorldDetail:
 
     @property
     def inhabited(self) -> bool:
+        """True if this world has a non-zero population."""
         return self.population > 0
 
     @property
@@ -371,6 +376,7 @@ class WorldDetail:
                 f"-{to_hex(self.tech_level)}")
 
     def to_dict(self) -> dict:
+        """Serialise this WorldDetail to a JSON-compatible dict."""
         return {
             "sah":         self.sah,
             "population":  self.population,
@@ -395,8 +401,7 @@ def _moons_for(detail: WorldDetail, orbit_number: float) -> list:
     if detail.is_gas_giant:
         cat = sah[1]                      # S, M, or L
         diam_hex = sah[2]
-        _EHEX2 = "0123456789ABCDEFGHIJ"
-        diam = _EHEX2.index(diam_hex) if diam_hex in _EHEX2 else 8
+        diam = _EHEX.index(diam_hex) if diam_hex in _EHEX else 8
         return generate_moons(
             size_code=diam, orbit_number=orbit_number,
             is_gas_giant=True, gg_category=cat, gg_diameter=diam,
@@ -409,7 +414,7 @@ def _moons_for(detail: WorldDetail, orbit_number: float) -> list:
     return generate_moons(size_code=sz, orbit_number=orbit_number)
 
 
-def _moon_detail(
+def _moon_detail(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-return-statements
     moon: Moon,
     hz_deviation: float,
     hzco: float,
@@ -461,8 +466,8 @@ def _moon_detail(
             pop = 0
         if pop == 0:
             return WorldDetail(sah=sah)
-        gov  = _secondary_government(pop, mw_pop, mw_gov)
-        law  = _secondary_law_level(gov, mw_gov, mw_law)
+        gov  = _secondary_government(mw_pop, mw_gov)
+        law  = _secondary_law_level(gov, mw_law)
         tl   = _secondary_tech_level(0, mw_tl)
         port = _spaceport(pop)
         return WorldDetail(sah=sah, population=pop, government=gov,
@@ -487,8 +492,8 @@ def _moon_detail(
         pop = 0
     if pop == 0:
         return WorldDetail(sah=sah)
-    gov  = _secondary_government(pop, mw_pop, mw_gov)
-    law  = _secondary_law_level(gov, mw_gov, mw_law)
+    gov  = _secondary_government(mw_pop, mw_gov)
+    law  = _secondary_law_level(gov, mw_law)
     tl   = _secondary_tech_level(atmosphere, mw_tl)
     port = _spaceport(pop)
     return WorldDetail(sah=sah, population=pop, government=gov,
@@ -498,7 +503,7 @@ def _moon_detail(
 # Main generation function
 # ---------------------------------------------------------------------------
 
-def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:
+def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """
     Generate WorldDetail for every non-mainworld, non-empty orbit slot.
 
@@ -546,8 +551,8 @@ def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:
             if pop == 0:
                 result[key] = WorldDetail(sah="000")
             else:
-                gov  = _secondary_government(pop, mw_pop, mw_gov)
-                law  = _secondary_law_level(gov, mw_gov, mw_law)
+                gov  = _secondary_government(mw_pop, mw_gov)
+                law  = _secondary_law_level(gov, mw_law)
                 tl   = _secondary_tech_level(belt_atm, mw_tl)
                 port = _spaceport(pop)
                 result[key] = WorldDetail(
@@ -580,8 +585,8 @@ def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:
             if pop == 0:
                 result[key] = WorldDetail(sah=sah)
             else:
-                gov  = _secondary_government(pop, mw_pop, mw_gov)
-                law  = _secondary_law_level(gov, mw_gov, mw_law)
+                gov  = _secondary_government(mw_pop, mw_gov)
+                law  = _secondary_law_level(gov, mw_law)
                 tl   = _secondary_tech_level(atm, mw_tl)
                 port = _spaceport(pop)
                 result[key] = WorldDetail(
@@ -622,7 +627,7 @@ def generate_system_detail(system: TravellerSystem) -> dict[str, WorldDetail]:
     return result
 
 
-def attach_detail(system: TravellerSystem) -> None:
+def attach_detail(system: TravellerSystem) -> None:  # pylint: disable=too-many-locals
     """
     Compute WorldDetail for all orbits and attach as `orbit.detail`
     on each OrbitSlot. Also attaches detail for the mainworld orbit
@@ -675,7 +680,7 @@ def attach_detail(system: TravellerSystem) -> None:
             orbit.detail = detail_map.get(key)
 
 
-def system_body_table(system: TravellerSystem) -> str:
+def system_body_table(system: TravellerSystem) -> str:  # pylint: disable=too-many-locals
     """
     Formatted table of all orbits with their physical and social profiles.
     Mainworld shows full UWP; inhabited secondaries show spaceport+SAH+PGL+TL;
@@ -717,7 +722,7 @@ def system_body_table(system: TravellerSystem) -> str:
         # Moon sub-rows: indented, showing SAH+social profile and trade codes
         for mi, moon in enumerate(moon_list, 1):
             if moon.is_ring:
-                ring_count = getattr(moon, "_ring_count", 1)
+                ring_count = moon.ring_count
                 moon_profile = f"R{ring_count:02d}"
                 moon_codes_str = ""
                 moon_sah_str = "ring system"
@@ -747,7 +752,7 @@ def system_body_table(system: TravellerSystem) -> str:
 
 if __name__ == "__main__":
     import argparse
-    from traveller_system_gen import generate_full_system
+    from traveller_system_gen import generate_full_system  # pylint: disable=import-outside-toplevel,ungrouped-imports
 
     parser = argparse.ArgumentParser(
         description="Generate a complete system with SAH/UWP for all worlds."

--- a/traveller_world_gen.py
+++ b/traveller_world_gen.py
@@ -32,6 +32,7 @@ This is an unofficial fan work, not affiliated with Mongoose Publishing.
 AI assistance disclosure: developed with Claude (Anthropic).
 The human author reviewed, directed, and is responsible for the code.
 """
+# pylint: disable=too-many-lines
 
 import json
 import random
@@ -175,16 +176,15 @@ def starport_class_from_roll(modified_roll: int) -> str:
     """Return the starport class letter for a given modified 2D roll."""
     if modified_roll <= 2:
         return "X"
-    elif modified_roll <= 4:
+    if modified_roll <= 4:
         return "E"
-    elif modified_roll <= 6:
+    if modified_roll <= 6:
         return "D"
-    elif modified_roll <= 8:
+    if modified_roll <= 8:
         return "C"
-    elif modified_roll <= 10:
+    if modified_roll <= 10:
         return "B"
-    else:
-        return "A"
+    return "A"
 
 # Starport quality labels (p.257) — the Quality column value
 STARPORT_QUALITY_LABEL = {
@@ -248,14 +248,13 @@ def temperature_category(modified_roll: int) -> str:
     """Return temperature category string from modified 2D roll (p.251)."""
     if modified_roll <= 2:
         return "Frozen"
-    elif modified_roll <= 4:
+    if modified_roll <= 4:
         return "Cold"
-    elif modified_roll <= 9:
+    if modified_roll <= 9:
         return "Temperate"
-    elif modified_roll <= 11:
+    if modified_roll <= 11:
         return "Hot"
-    else:
-        return "Boiling"
+    return "Boiling"
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +262,7 @@ def temperature_category(modified_roll: int) -> str:
 # ---------------------------------------------------------------------------
 
 @dataclass
-class World:
+class World:  # pylint: disable=too-many-instance-attributes
     """Holds all generated characteristics for one mainworld."""
     name:           str   = "Unknown"
     size:           int   = 0
@@ -403,9 +402,9 @@ class World:
             except (TypeError, ValueError):
                 return default
 
-        def _code(field: object) -> object:
-            """Return field['code'] when field is a dict, else field itself."""
-            return field.get("code") if isinstance(field, dict) else field
+        def _code(val: object) -> object:
+            """Return val['code'] when val is a dict, else val itself."""
+            return val.get("code") if isinstance(val, dict) else val  # type: ignore[union-attr]
 
         gas_giant_count = _int(_code(d.get("gas_giant_count", 0)))
 
@@ -471,7 +470,7 @@ class World:
             return "era-avgstellar"
         return "era-highstellar"
 
-    def to_html(self) -> str:
+    def to_html(self) -> str:  # pylint: disable=too-many-locals
         """Return a self-contained HTML card representing this world.
 
         The output matches the inline display widget shown in Claude
@@ -793,6 +792,7 @@ class World:
     # Human-readable summary
     # ------------------------------------------------------------------
     def summary(self) -> str:
+        """Return a human-readable summary of this world's characteristics."""
         pop_range = {
             0: "None", 1: "Few (1+)", 2: "Hundreds", 3: "Thousands",
             4: "Tens of thousands", 5: "Hundreds of thousands",
@@ -968,9 +968,10 @@ def generate_starport(population: int) -> str:
     return starport_class_from_roll(modified)
 
 
-def generate_tech_level(starport: str, size: int, atmosphere: int,
-                        hydrographics: int, population: int,
-                        government: int) -> int:
+def generate_tech_level(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        starport: str, size: int, atmosphere: int,
+        hydrographics: int, population: int,
+        government: int) -> int:
     """Step 9 — Tech Level (p.258-259): roll 1D + multiple DMs.
 
     DMs come from Starport, Size, Atmosphere, Hydrographics,
@@ -1131,16 +1132,15 @@ def generate_gas_giant_count() -> int:
     result = roll(2)
     if result <= 4:
         return 1
-    elif result <= 6:
+    if result <= 6:
         return 2
-    elif result <= 8:
+    if result <= 8:
         return 3
-    elif result <= 11:
+    if result <= 11:
         return 4
-    elif result == 12:
+    if result == 12:
         return 5
-    else:
-        return 6
+    return 6
 
 
 def generate_belt_count(has_gas_giant: bool, size: int) -> int:
@@ -1188,9 +1188,10 @@ def generate_gas_giant() -> bool:
     return roll(2) <= 9  # 10+ means no gas giant
 
 
-def assign_trade_codes(size: int, atmosphere: int, hydrographics: int,
-                       population: int, government: int,
-                       law_level: int, tech_level: int) -> List[str]:
+def assign_trade_codes(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-branches
+        size: int, atmosphere: int, hydrographics: int,
+        population: int, government: int,
+        law_level: int, tech_level: int) -> List[str]:
     """Step 12 — Trade Codes (p.260-261).
 
     Each code is awarded if ALL listed criteria are met.  Criteria are
@@ -1233,7 +1234,7 @@ def assign_trade_codes(size: int, atmosphere: int, hydrographics: int,
         codes.append("Ht")
 
     # Ice-Capped (Ic): thin, near-frozen atmosphere with some water ice
-    if atmosphere <= 1 and hydrographics >= 1:
+    if atmosphere <= 1 <= hydrographics:
         codes.append("Ic")
 
     # Industrial (In): heavy industrial base
@@ -1403,7 +1404,8 @@ def generate_world(name: str = "Unknown") -> World:
 # CLI entry point
 # ---------------------------------------------------------------------------
 
-def main():
+def main():  # pylint: disable=too-many-branches
+    """Generate and print Traveller mainworlds from the command line."""
     parser = argparse.ArgumentParser(
         description="Generate Traveller (2022) mainworlds.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1462,7 +1464,7 @@ def main():
             # Multiple worlds: wrap all cards in one HTML page.
             # Strip the outer <html>…</body> wrapper from each card after
             # the first, keeping only the inner <div class="world-card">.
-            import re
+            import re  # pylint: disable=import-outside-toplevel
             cards_html = []
             for w in worlds:
                 full = w.to_html()


### PR DESCRIPTION
## Summary

This branch brings the codebase up to date across multiple sessions of work since the last PR merge:

**Pylint (Session 22)**
- All six generation modules now score 10.00/10 per file
- Added docstrings to undocumented methods/properties; flattened elif-after-return chains (R1705); expanded inline statements (C0321); renamed unused parameters; used chained comparisons (R1716); added `locally-disabled,suppressed-message` to suppress I0011/I0020 noise
- Fixed `_size_gg_moon()` indentation bug: gas-giant sizing block was structurally unreachable after `else:` removal
- Updated `docs/developer-guide.md` with pylint guidance and suppression table

**gen-ui SystemMapWindow (Session 21)**
- Separate non-modal `QMainWindow` displaying SVG system map via `QSvgWidget`
- Dark/light theme toggle and Save SVG button
- Fixed Qt SVG rendering: explicit `<rect fill>` background, monospace font inheritance in table zone

**Pylance type-checking fixes (Sessions 19–20)**
- `OrbitSlot.detail` promoted to proper typed `Optional[WorldDetail]` field
- `gen-ui/app.py`: `QApplication.instance()` narrowed via `isinstance`; `None` guards on layout items; `orbit.world_type` cast to `str`
- Dependency audit CI: `pip-audit` on every push/PR, hard-fails on CVEs

**PySide6 migration (Session 17)**
- Rewrote `gen-ui/app.py` from GTK4/PyGObject to PySide6 (Qt6)
- `QKeySequence::Quit/Close` provides correct cross-platform shortcuts automatically

**SVG system map (Session 14–15)**
- New `system_map.py`: log-AU radial scale, per-star arc zones, orbit detail table
- White/dark background themes via `ColourPalette` dataclass and `--white-bg` flag

**Compliance fixes**
- Ag trade code (Session 15): corrected all four CRB p.260 criteria; six boundary tests added
- Temperature (Session 12): removed sub-Orbit#1 deviation scaling; 0% frozen-in-HZ post-fix
- Gas giant mainworld (Session 13): mainworld now treated as satellite, size clamped to `[1, gg_diam-1]`

## Test plan

- [ ] `pytest tests/ -v` → 523 passed, 0 failed
- [ ] `.venv-1/bin/pylint traveller_stellar_gen.py traveller_orbit_gen.py traveller_system_gen.py traveller_world_gen.py traveller_world_detail.py traveller_moon_gen.py` → 10.00/10 per file
- [ ] `python gen-ui/app.py` → UI launches, procedural and TravellerMap generation work, System Map button opens SVG window
- [ ] `python system_map.py --seed 42 --out test.svg` → valid SVG renders in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)