### PR TITLE
fix: bootstrap pip via ensurepip on Fedora (python3.11-pip absent in Fedora 44)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -129,9 +129,10 @@ jobs:
       - name: Install system dependencies
         run: |
           dnf install -y \
-            python3.11 python3.11-pip python3.11-devel \
+            python3.11 python3.11-devel \
             gcc gcc-c++ git \
             xcb-util-wm xcb-util-image xcb-util-keysyms xcb-util-renderutil
+          python3.11 -m ensurepip --upgrade
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

- `python3.11-pip` does not exist as a dnf package on Fedora 44.
- Removed it from the `dnf install` list in the Fedora build job.
- Added `python3.11 -m ensurepip --upgrade` to bootstrap pip from the standard library instead.

## Test plan

- [ ] Fedora build job in `build-binaries` workflow completes without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)