### PR TITLE
ci: add workflow_dispatch trigger to build-binaries workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,6 +1,7 @@
 name: Build binaries
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` trigger to `build-binaries.yml` so the workflow can be run manually from the GitHub Actions UI without needing a push to `main`.

## Test plan

- [x] Verify **Actions → Build binaries → Run workflow** button appears on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)