### PR TITLE
v1.3.1: Windows binary fixes and macOS Gatekeeper docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ run-mapfetch.bat
 # Regenerate with: python traveller_world_gen.py --name <name> --html
 examples/*.html
 
+# ── Scratch / working notes ─────────────────────────────────────────────────
+v13.md
+
 # ── Claude Code context ─────────────────────────────────────────────────────
 # Project context and session history — internal development notes not
 # intended for the public repository.

--- a/docs/MACOS-GATEKEEPER.md
+++ b/docs/MACOS-GATEKEEPER.md
@@ -1,8 +1,40 @@
 # Running on macOS — Gatekeeper
 
 Because the Traveller World Generator is not signed with an Apple Developer
-certificate, macOS Gatekeeper will block it from opening on the first launch.
-There are two ways to allow it.
+certificate, macOS Gatekeeper may block both extraction of the archive and
+the first launch of the app. The instructions below cover both situations.
+
+---
+
+## Part 1 — Extracting the archive
+
+macOS may refuse to extract `TravellerWorldGen-macos.zip` with the error
+*"unable to expand"* or silently produce an empty folder. This happens because
+Gatekeeper quarantines the downloaded zip before it is opened.
+
+### Option A — Remove quarantine from the zip first (recommended)
+
+Run this in Terminal before double-clicking the zip:
+
+```bash
+xattr -dr com.apple.quarantine ~/Downloads/TravellerWorldGen-macos.zip
+```
+
+Then double-click the zip to extract it normally.
+
+### Option B — Extract using Terminal
+
+```bash
+cd ~/Downloads
+unzip TravellerWorldGen-macos.zip
+```
+
+The `unzip` command is not subject to Gatekeeper and will extract the app
+without error.
+
+---
+
+## Part 2 — Opening the app
 
 ---
 

--- a/docs/MACOS-GATEKEEPER.md
+++ b/docs/MACOS-GATEKEEPER.md
@@ -1,0 +1,57 @@
+# Running on macOS — Gatekeeper
+
+Because the Traveller World Generator is not signed with an Apple Developer
+certificate, macOS Gatekeeper will block it from opening on the first launch.
+There are two ways to allow it.
+
+---
+
+## Method 1 — Right-click to open (easiest)
+
+1. Unzip `TravellerWorldGen-macos.zip`.
+2. **Right-click** (or Control-click) `TravellerWorldGen.app`.
+3. Select **Open** from the context menu.
+4. A dialog will appear warning that the app is from an unidentified developer.
+   Click **Open**.
+
+macOS remembers your choice — subsequent launches work normally by
+double-clicking.
+
+---
+
+## Method 2 — System Settings
+
+If the right-click method does not show an **Open** option:
+
+1. Attempt to open the app by double-clicking. macOS will block it and show a
+   warning dialog — click **Done**.
+2. Open **System Settings → Privacy & Security**.
+3. Scroll down to the **Security** section. You will see a message:
+   *"TravellerWorldGen.app was blocked because it is not from an identified
+   developer."*
+4. Click **Open Anyway**.
+5. Authenticate with your password or Touch ID when prompted.
+
+---
+
+## Method 3 — Terminal (advanced)
+
+If neither method above works, remove the quarantine attribute manually:
+
+```bash
+xattr -dr com.apple.quarantine /path/to/TravellerWorldGen.app
+```
+
+Replace `/path/to/` with the actual location of the app (e.g.
+`~/Downloads/TravellerWorldGen.app`). After running this command the app will
+open normally.
+
+---
+
+## Why does this happen?
+
+Apple Gatekeeper blocks apps that are not signed with an Apple Developer ID
+certificate and notarized by Apple. Obtaining and maintaining a Developer ID
+requires an annual Apple Developer Program membership. This is a known
+limitation of the current release; code signing and notarization are planned
+for a future version.

--- a/gen-ui/requirements.txt
+++ b/gen-ui/requirements.txt
@@ -10,16 +10,6 @@
 #   .venv/bin/python3 gen-ui/app.py
 #
 PySide6>=6.4.0
-
-# HTML rendering
-#
-# The app displays generated world cards as native Qt widgets.
-# The full HTML card is still available via Open in Browser and Save as HTML.
-# To embed HTML in-app on any platform, WebEngineWidgets is available in
-# PySide6 (PySide6-Essentials includes QtWebEngineWidgets):
-#
-#   from PySide6.QtWebEngineWidgets import QWebEngineView
-#   view = QWebEngineView()
-#   view.setHtml(html)
-#
-# This is a deferred feature — the current in-app card uses native widgets.
+# PySide6-Addons provides QtWebEngineWidgets (used by the System tab).
+# On Windows and some Linux distros PySide6 alone does not pull it in.
+PySide6-Addons>=6.4.0

--- a/install.bat
+++ b/install.bat
@@ -125,7 +125,7 @@ if errorlevel 1 (
     exit /b 1
 )
 
-echo [install] Installing PySide6 (desktop GUI library) - this may take a few minutes...
+echo [install] Installing PySide6 and PySide6-Addons (desktop GUI library) - this may take a few minutes...
 "!VENV_PYTHON!" -m pip install --quiet -r "%~dp0gen-ui\requirements.txt"
 if errorlevel 1 (
     echo [error]   Failed to install PySide6. Check your internet connection and try again.

--- a/install.ps1
+++ b/install.ps1
@@ -131,6 +131,12 @@ if ($LASTEXITCODE -ne 0) {
     Fail "Failed to install PySide6. Check your internet connection and try again."
 }
 
+Info "Installing PySide6-Addons (Qt WebEngine and additional Qt modules)..."
+& $VenvPython -m pip install --quiet PySide6-Addons
+if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to install PySide6-Addons. Check your internet connection and try again."
+}
+
 Info "Installing dev tools (pytest, pylint)..."
 & $VenvPython -m pip install --quiet -r (Join-Path $ScriptDir 'requirements-dev.txt')
 if ($LASTEXITCODE -ne 0) { Fail "Failed to install dev tools." }

--- a/install.ps1
+++ b/install.ps1
@@ -137,6 +137,12 @@ if ($LASTEXITCODE -ne 0) {
     Fail "Failed to install PySide6-Addons. Check your internet connection and try again."
 }
 
+Info "Installing PyQt6-WebEngine..."
+& $VenvPython -m pip install --quiet PyQt6-WebEngine
+if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to install PyQt6-WebEngine. Check your internet connection and try again."
+}
+
 Info "Installing dev tools (pytest, pylint)..."
 & $VenvPython -m pip install --quiet -r (Join-Path $ScriptDir 'requirements-dev.txt')
 if ($LASTEXITCODE -ne 0) { Fail "Failed to install dev tools." }

--- a/install.ps1
+++ b/install.ps1
@@ -131,17 +131,6 @@ if ($LASTEXITCODE -ne 0) {
     Fail "Failed to install PySide6. Check your internet connection and try again."
 }
 
-Info "Installing PySide6-Addons (Qt WebEngine and additional Qt modules)..."
-& $VenvPython -m pip install --quiet PySide6-Addons
-if ($LASTEXITCODE -ne 0) {
-    Fail "Failed to install PySide6-Addons. Check your internet connection and try again."
-}
-
-Info "Installing PyQt6-WebEngine..."
-& $VenvPython -m pip install --quiet PyQt6-WebEngine
-if ($LASTEXITCODE -ne 0) {
-    Fail "Failed to install PyQt6-WebEngine. Check your internet connection and try again."
-}
 
 Info "Installing dev tools (pytest, pylint)..."
 & $VenvPython -m pip install --quiet -r (Join-Path $ScriptDir 'requirements-dev.txt')

--- a/install.sh
+++ b/install.sh
@@ -129,7 +129,7 @@ info "Installing backend dependencies (azure-functions, jsonschema)..."
 "$VENV_PYTHON" -m pip install --quiet -r "$SCRIPT_DIR/requirements.txt" \
     || fail "Failed to install backend dependencies."
 
-info "Installing PySide6 (desktop GUI library) — this may take a few minutes..."
+info "Installing PySide6 and PySide6-Addons (desktop GUI library) — this may take a few minutes..."
 "$VENV_PYTHON" -m pip install --quiet -r "$SCRIPT_DIR/gen-ui/requirements.txt" \
     || fail "Failed to install PySide6. Check your internet connection and try again."
 

--- a/traveller_gen_ui.spec
+++ b/traveller_gen_ui.spec
@@ -6,17 +6,49 @@ Run from the project root:
     .venv/bin/pyinstaller traveller_gen_ui.spec
 
 Output:
-    dist/TravellerWorldGen.app   (macOS app bundle)
+    dist/TravellerWorldGen/   (one-dir bundle, all platforms)
+    dist/TravellerWorldGen.app  (macOS app bundle wrapper)
 """
+
+import os
+import sys
+from PyInstaller.utils.hooks import collect_data_files
+
+# ---------------------------------------------------------------------------
+# QtWebEngine support
+# ---------------------------------------------------------------------------
+# When PySide6-Addons is installed separately from the base PySide6 package,
+# PyInstaller's built-in hooks may not collect the WebEngine process binary
+# and resource files. Collect them explicitly here.
+
+_webengine_datas = []
+for _subdir in ("Qt/resources", "Qt/translations/qtwebengine_locales"):
+    _webengine_datas += collect_data_files("PySide6", subdir=_subdir)
+
+# QtWebEngineProcess is a standalone executable required by QtWebEngine.
+# On Windows: QtWebEngineProcess.exe; on Linux/macOS: QtWebEngineProcess.
+import PySide6 as _pyside6
+_pyside6_dir = os.path.dirname(_pyside6.__file__)
+_webengine_process_name = (
+    "QtWebEngineProcess.exe" if sys.platform == "win32" else "QtWebEngineProcess"
+)
+_webengine_process = os.path.join(_pyside6_dir, _webengine_process_name)
+_webengine_binaries = [(_webengine_process, ".")] if os.path.isfile(_webengine_process) else []
+
+# ---------------------------------------------------------------------------
 
 a = Analysis(
     ["gen-ui/app.py"],
     pathex=["."],
-    binaries=[],
+    binaries=_webengine_binaries,
     datas=[
         ("templates", "templates"),
+        *_webengine_datas,
     ],
-    hiddenimports=[],
+    hiddenimports=[
+        "PySide6.QtWebEngineCore",
+        "PySide6.QtWebEngineWidgets",
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],


### PR DESCRIPTION
## Summary

Patch release fixing Windows binary issues introduced in v1.3.0.

## Changes

- **fix**: Bundle `QtWebEngineProcess.exe` and WebEngine resource files in PyInstaller spec — web views were blank in the Windows binary because these files were not collected when `PySide6-Addons` is installed separately
- **fix**: Add `PySide6-Addons>=6.4.0` to `gen-ui/requirements.txt` — `QtWebEngineWidgets` not found on Windows without it
- **docs**: macOS Gatekeeper bypass instructions (`docs/MACOS-GATEKEEPER.md`) including archive extraction workaround
- **chore**: Remove erroneous `PyQt6-WebEngine` install step (wrong package — for PyQt6, not PySide6); `PySide6-Addons` now covered by requirements file

## Test plan

- [ ] Windows binary launches and System tab renders HTML correctly
- [ ] `pip install -r gen-ui/requirements.txt` installs `PySide6-Addons` on a clean Windows environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)